### PR TITLE
feat(api): implement professional public IDs for forms (rk_frm_...)

### DIFF
--- a/apps/admin/src/components/dashboard/form-table.tsx
+++ b/apps/admin/src/components/dashboard/form-table.tsx
@@ -27,7 +27,9 @@ import {
   MessageSquare,
   FileText,
   ChevronLeft,
-  ChevronRight
+  ChevronRight,
+  Copy,
+  Check
 } from 'lucide-react';
 import { Badge, Stars } from './ui';
 import type { DashboardForm } from './types';
@@ -53,11 +55,20 @@ const SortableRow = ({ form, isSelected, onSelect, onOpen, onDelete, onDuplicate
     isDragging
   } = useSortable({ id: form.id });
 
+  const [isCopied, setIsCopied] = useState(false);
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     zIndex: isDragging ? 50 : 'auto',
     opacity: isDragging ? 0.5 : 1,
+  };
+
+  const copyId = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(form.publicId);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
   };
 
 
@@ -93,7 +104,16 @@ const SortableRow = ({ form, isSelected, onSelect, onOpen, onDelete, onDuplicate
             <div className="font-bold text-[var(--v3-text)] truncate" title={form.name}>
               {form.name.length > 25 ? form.name.substring(0, 25) + '...' : form.name}
             </div>
-            <div className="text-[9px] text-[var(--v3-muted2)] font-mono truncate opacity-50">/f/{form.slug}</div>
+            <div className="flex items-center gap-1.5 mt-0.5 group/id">
+              <div className="text-[9px] text-[var(--v3-muted2)] font-mono truncate opacity-40">ID: {form.publicId.substring(0, 10)}...</div>
+              <button 
+                onClick={copyId}
+                className={`opacity-0 group-hover/id:opacity-100 p-0.5 rounded transition-all ${isCopied ? 'text-emerald-500' : 'text-[var(--v3-muted2)] hover:text-[var(--v3-teal)] hover:bg-white/5'}`}
+                title="Copier l'ID"
+              >
+                {isCopied ? <Check size={10} /> : <Copy size={10} />}
+              </button>
+            </div>
           </div>
         </div>
       </td>

--- a/apps/admin/src/components/dashboard/share-modal.tsx
+++ b/apps/admin/src/components/dashboard/share-modal.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
-import { X, Copy, Check, Globe, Twitter, Linkedin, Facebook } from 'lucide-react';
+import { X, Copy, Check, Globe, Twitter, Linkedin, Facebook, FileText } from 'lucide-react';
 
 interface ShareModalProps {
   isOpen: boolean;
   onClose: () => void;
   formName: string;
   formSlug: string;
+  publicId: string;
 }
 
-export const ShareModal = ({ isOpen, onClose, formName, formSlug }: ShareModalProps) => {
+export const ShareModal = ({ isOpen, onClose, formName, formSlug, publicId }: ShareModalProps) => {
   const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedId, setCopiedId] = useState(false);
 
   if (!isOpen) return null;
 
@@ -19,6 +21,12 @@ export const ShareModal = ({ isOpen, onClose, formName, formSlug }: ShareModalPr
     navigator.clipboard.writeText(shareUrl);
     setCopiedLink(true);
     setTimeout(() => setCopiedLink(false), 2000);
+  };
+
+  const copyId = () => {
+    navigator.clipboard.writeText(publicId);
+    setCopiedId(true);
+    setTimeout(() => setCopiedId(false), 2000);
   };
 
   const shareSocial = (platform: 'twitter' | 'linkedin' | 'facebook') => {
@@ -67,6 +75,31 @@ export const ShareModal = ({ isOpen, onClose, formName, formSlug }: ShareModalPr
                   {copiedLink ? 'Copié' : 'Copier'}
                 </button>
               </div>
+            </div>
+
+            {/* Form ID for API */}
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <FileText size={14} className="text-purple-400" />
+                <span className="text-[11px] font-bold uppercase tracking-wider text-[var(--v3-muted2)]">ID du formulaire (API)</span>
+              </div>
+              <div className="flex gap-2">
+                <input 
+                  readOnly 
+                  value={publicId}
+                  className="flex-1 bg-black/20 border border-white/5 rounded-xl px-4 py-3 text-sm text-[var(--v3-muted2)] focus:outline-none focus:border-purple-500/30 transition-all font-mono"
+                />
+                <button 
+                  onClick={copyId}
+                  className={`px-4 rounded-xl flex items-center gap-2 font-bold text-xs uppercase transition-all ${copiedId ? 'bg-emerald-500 text-white' : 'bg-purple-600/80 text-white hover:bg-purple-600 hover:shadow-[0_8px_20px_rgba(147,51,234,0.2)]'}`}
+                >
+                  {copiedId ? <Check size={16} /> : <Copy size={16} />}
+                  {copiedId ? 'Copié' : 'Copier'}
+                </button>
+              </div>
+              <p className="mt-2 text-[10px] text-[var(--v3-muted2)] italic">
+                Utilise cet ID pour tes requêtes API publiques.
+              </p>
             </div>
 
             {/* Social Sharing */}

--- a/apps/admin/src/components/dashboard/types.ts
+++ b/apps/admin/src/components/dashboard/types.ts
@@ -3,6 +3,7 @@ export interface DashboardForm {
   userId: string
   name: string
   slug: string
+  publicId: string
   description?: string
   status?: string
   isActive?: boolean

--- a/apps/admin/src/pages/DashboardPage.tsx
+++ b/apps/admin/src/pages/DashboardPage.tsx
@@ -29,6 +29,12 @@ export default function DashboardPage() {
   const [bulkDeletingIds, setBulkDeletingIds] = useState<string[] | null>(null)
   const [sharingFormId, setSharingFormId] = useState<string | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [stats, setStats] = useState({
+    totalReviews: 0,
+    completionRate: 0,
+    averageRating: 0.0,
+    uniqueRespondents: 0
+  })
 
   useEffect(() => {
     const fetchData = async () => {
@@ -42,7 +48,17 @@ export default function DashboardPage() {
       }
     };
 
+    const fetchStats = async () => {
+      try {
+        const res = await fetch('/api/v1/dashboard/stats');
+        if (res.ok) setStats(await res.json());
+      } catch (error) {
+        console.error("Failed to fetch dashboard stats", error);
+      }
+    };
+
     fetchData();
+    fetchStats();
   }, [])
 
   const selectedForm = useMemo(() => 
@@ -157,10 +173,33 @@ export default function DashboardPage() {
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-14">
-            <StatCard icon={<MessageSquare size={18} />} label="Total reviews" value="0" delta="↑ 0%" colorClass="bg-[var(--v3-teal-dim)] border-[var(--v3-teal)]/20 text-[var(--v3-teal)]" />
-            <StatCard icon={<CheckCircle2 size={18} />} label="Taux de complétion" value="0%" delta="↑ 0%" colorClass="bg-emerald-500/10 border-emerald-500/20 text-emerald-500" />
-            <StatCard icon={<Star size={18} />} label="Note moyenne" value="0.0" colorClass="bg-amber-500/10 border-amber-500/20 text-amber-500" />
-            <StatCard icon={<Users size={18} />} label="Répondants uniques" value="0" delta="↑ 0%" colorClass="bg-sky-500/10 border-sky-500/20 text-sky-500" />
+            <StatCard 
+              icon={<MessageSquare size={18} />} 
+              label="Total reviews" 
+              value={stats.totalReviews.toString()} 
+              delta="↑ 0%" 
+              colorClass="bg-[var(--v3-teal-dim)] border-[var(--v3-teal)]/20 text-[var(--v3-teal)]" 
+            />
+            <StatCard 
+              icon={<CheckCircle2 size={18} />} 
+              label="Taux de complétion" 
+              value={`${stats.completionRate}%`} 
+              delta="↑ 0%" 
+              colorClass="bg-emerald-500/10 border-emerald-500/20 text-emerald-500" 
+            />
+            <StatCard 
+              icon={<Star size={18} />} 
+              label="Note moyenne" 
+              value={stats.averageRating.toFixed(1)} 
+              colorClass="bg-amber-500/10 border-amber-500/20 text-amber-500" 
+            />
+            <StatCard 
+              icon={<Users size={18} />} 
+              label="Répondants uniques" 
+              value={stats.uniqueRespondents.toString()} 
+              delta="↑ 0%" 
+              colorClass="bg-sky-500/10 border-sky-500/20 text-sky-500" 
+            />
           </div>
 
           <div className="flex justify-between items-center mb-6 gap-4 flex-wrap">
@@ -237,6 +276,7 @@ export default function DashboardPage() {
         onClose={() => setSharingFormId(null)}
         formName={forms.find(f => f.id === sharingFormId)?.name || ''}
         formSlug={forms.find(f => f.id === sharingFormId)?.slug || ''}
+        publicId={forms.find(f => f.id === sharingFormId)?.publicId || ''}
       />
     </div>
   )

--- a/apps/server/src/application/use-cases/dashboard/GetDashboardStats.ts
+++ b/apps/server/src/application/use-cases/dashboard/GetDashboardStats.ts
@@ -1,0 +1,23 @@
+import type { TestimonialRepository } from '../../../domain/repositories/TestimonialRepository';
+
+export interface DashboardStats {
+  totalReviews: number;
+  averageRating: number;
+  uniqueRespondents: number;
+  completionRate: number; // Placeholder for now
+}
+
+export class GetDashboardStats {
+  constructor(private readonly testimonialRepository: TestimonialRepository) {}
+
+  async execute(userId: string): Promise<DashboardStats> {
+    const stats = await this.testimonialRepository.getStatsByUser(userId);
+    
+    return {
+      totalReviews: stats.totalReviews,
+      averageRating: Number(stats.averageRating.toFixed(1)),
+      uniqueRespondents: stats.uniqueRespondents,
+      completionRate: 0, // Still 0 until we have a way to track views
+    };
+  }
+}

--- a/apps/server/src/domain/entities/Form.ts
+++ b/apps/server/src/domain/entities/Form.ts
@@ -6,6 +6,7 @@ export interface FormProps {
   userId: string;
   name: string;
   slug: Slug;
+  publicId: string;
   description?: string;
   thankYouMessage?: string;
   config?: Record<string, any>;
@@ -20,6 +21,7 @@ export class Form {
   public readonly userId: string;
   private name: string;
   private slug: Slug;
+  public readonly publicId: string;
   private description?: string;
   private thankYouMessage?: string;
   private config: Record<string, any>;
@@ -35,6 +37,7 @@ export class Form {
     this.userId = props.userId;
     this.name = props.name;
     this.slug = props.slug;
+    this.publicId = props.publicId;
     this.description = props.description;
     this.thankYouMessage = props.thankYouMessage;
     this.config = props.config ?? {};
@@ -50,6 +53,7 @@ export class Form {
       userId: this.userId,
       name: this.name,
       slug: this.slug,
+      publicId: this.publicId,
       description: this.description,
       thankYouMessage: this.thankYouMessage,
       config: { ...this.config },

--- a/apps/server/src/domain/repositories/FormRepository.ts
+++ b/apps/server/src/domain/repositories/FormRepository.ts
@@ -3,6 +3,7 @@ import { Form } from '../entities/Form';
 export interface FormRepository {
   findById(id: string): Promise<Form | null>;
   findBySlug(userId: string, slug: string): Promise<Form | null>;
+  findByPublicId(publicId: string): Promise<Form | null>;
   findByUser(userId: string): Promise<Form[]>;
   save(form: Form): Promise<void>;
   update(form: Form): Promise<void>;

--- a/apps/server/src/domain/repositories/TestimonialRepository.ts
+++ b/apps/server/src/domain/repositories/TestimonialRepository.ts
@@ -6,5 +6,10 @@ export interface TestimonialRepository {
   save(testimonial: Testimonial): Promise<void>;
   update(testimonial: Testimonial): Promise<void>;
   delete(id: string): Promise<void>;
-  findApprovedByUser(userId: string, options?: { limit?: number; minRating?: number }): Promise<Testimonial[]>;
+  findApprovedByUser(userId: string, options: { limit?: number; minRating?: number; formId: string }): Promise<Testimonial[]>;
+  getStatsByUser(userId: string): Promise<{
+    totalReviews: number;
+    averageRating: number;
+    uniqueRespondents: number;
+  }>;
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@ import { meRouter } from './interface/routes/me';
 import { formsRouter } from './interface/routes/forms';
 import { apiKeysRouter } from './interface/routes/api-keys';
 import { publicRouter } from './interface/routes/public';
+import { dashboardRouter } from './interface/routes/dashboard';
 
 const app = new OpenAPIHono();
 
@@ -61,6 +62,7 @@ app.route('/api/v1/admin', adminRouter);
 app.route('/api/v1/forms', formsRouter);
 app.route('/api/v1/api-keys', apiKeysRouter);
 app.route('/api/v1/public', publicRouter);
+app.route('/api/v1/dashboard', dashboardRouter);
 
 // Welcome Route
 app.get('/', (c) => {

--- a/apps/server/src/infrastructure/container.ts
+++ b/apps/server/src/infrastructure/container.ts
@@ -4,6 +4,7 @@ import { DrizzleTestimonialRepository } from './repositories/DrizzleTestimonialR
 import { DrizzleApiKeyRepository } from './repositories/DrizzleApiKeyRepository';
 import { GenerateUserApiKeys } from '../application/use-cases/api-keys/GenerateUserApiKeys';
 import { VerifyApiKey } from '../application/use-cases/api-keys/VerifyApiKey';
+import { GetDashboardStats } from '../application/use-cases/dashboard/GetDashboardStats';
 
 // Repositories
 const formRepository = new DrizzleFormRepository(db);
@@ -13,6 +14,7 @@ const apiKeyRepository = new DrizzleApiKeyRepository(db);
 // Use Cases
 const generateUserApiKeys = new GenerateUserApiKeys(apiKeyRepository);
 const verifyApiKey = new VerifyApiKey(apiKeyRepository);
+const getDashboardStats = new GetDashboardStats(testimonialRepository);
 
 export const container = {
   formRepository,
@@ -20,4 +22,5 @@ export const container = {
   apiKeyRepository,
   generateUserApiKeys,
   verifyApiKey,
+  getDashboardStats,
 };

--- a/apps/server/src/infrastructure/database/schema.ts
+++ b/apps/server/src/infrastructure/database/schema.ts
@@ -79,6 +79,7 @@ export const forms = pgTable('forms', {
   userId: uuid('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
   name: text('name').notNull(),
   slug: text('slug').unique().notNull(),
+  publicId: text('public_id').unique().notNull(),
   description: text('description'),
   thankYouMessage: text('thank_you_message'),
   config: jsonb('config').default({}),

--- a/apps/server/src/infrastructure/repositories/DrizzleFormRepository.ts
+++ b/apps/server/src/infrastructure/repositories/DrizzleFormRepository.ts
@@ -25,6 +25,13 @@ export class DrizzleFormRepository implements FormRepository {
     return this.mapToDomain(row);
   }
 
+  async findByPublicId(publicId: string): Promise<Form | null> {
+    const [row] = await this.db.select().from(forms).where(eq(forms.publicId, publicId));
+    if (!row) return null;
+
+    return this.mapToDomain(row);
+  }
+
   async findByUser(userId: string): Promise<Form[]> {
     const rows = await this.db.select().from(forms).where(eq(forms.userId, userId));
     return rows.map(row => this.mapToDomain(row));
@@ -37,6 +44,7 @@ export class DrizzleFormRepository implements FormRepository {
       userId: props.userId,
       name: props.name,
       slug: props.slug.getValue(),
+      publicId: props.publicId,
       description: props.description,
       thankYouMessage: props.thankYouMessage,
       config: props.config,
@@ -53,6 +61,7 @@ export class DrizzleFormRepository implements FormRepository {
       .set({
         name: props.name,
         slug: props.slug.getValue(),
+        publicId: props.publicId,
         description: props.description,
         thankYouMessage: props.thankYouMessage,
         config: props.config,
@@ -85,6 +94,7 @@ export class DrizzleFormRepository implements FormRepository {
       userId: row.userId,
       name: row.name,
       slug: Slug.create(row.slug),
+      publicId: row.publicId,
       description: row.description || undefined,
       thankYouMessage: row.thankYouMessage || undefined,
       config: row.config as Record<string, any>,

--- a/apps/server/src/infrastructure/repositories/DrizzleTestimonialRepository.ts
+++ b/apps/server/src/infrastructure/repositories/DrizzleTestimonialRepository.ts
@@ -1,4 +1,4 @@
-import { eq, and } from 'drizzle-orm';
+import { eq, and, sql, count, avg, countDistinct } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../database/schema';
 import { testimonials } from '../database/schema';
@@ -74,7 +74,7 @@ export class DrizzleTestimonialRepository implements TestimonialRepository {
     await this.db.delete(testimonials).where(eq(testimonials.id, id));
   }
 
-  async findApprovedByUser(userId: string, options?: { limit?: number; minRating?: number }): Promise<Testimonial[]> {
+  async findApprovedByUser(userId: string, options: { limit?: number; minRating?: number; formId: string }): Promise<Testimonial[]> {
     const { gte } = await import('drizzle-orm');
     const whereConditions = [
       eq(testimonials.userId, userId),
@@ -83,6 +83,10 @@ export class DrizzleTestimonialRepository implements TestimonialRepository {
 
     if (options?.minRating) {
       whereConditions.push(gte(testimonials.rating, options.minRating));
+    }
+
+    if (options?.formId) {
+      whereConditions.push(eq(testimonials.formId, options.formId));
     }
 
     const query = this.db.select()
@@ -96,6 +100,26 @@ export class DrizzleTestimonialRepository implements TestimonialRepository {
 
     const rows = await query;
     return rows.map(row => this.mapToDomain(row));
+  }
+
+  async getStatsByUser(userId: string): Promise<{
+    totalReviews: number;
+    averageRating: number;
+    uniqueRespondents: number;
+  }> {
+    const [result] = await this.db.select({
+      totalReviews: count(testimonials.id),
+      averageRating: avg(testimonials.rating),
+      uniqueRespondents: countDistinct(testimonials.authorEmail),
+    })
+    .from(testimonials)
+    .where(eq(testimonials.userId, userId));
+
+    return {
+      totalReviews: Number(result?.totalReviews) || 0,
+      averageRating: Number(result?.averageRating) || 0,
+      uniqueRespondents: Number(result?.uniqueRespondents) || 0,
+    };
   }
 
   private mapToDomain(row: any): Testimonial {

--- a/apps/server/src/interface/controllers/dashboardController.ts
+++ b/apps/server/src/interface/controllers/dashboardController.ts
@@ -1,0 +1,20 @@
+import type { Context } from 'hono';
+import { container } from '@/infrastructure/container';
+
+export const dashboardController = {
+  getStats: async (c: Context) => {
+    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    
+    if (!userId) {
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    try {
+      const stats = await container.getDashboardStats.execute(userId);
+      return c.json(stats);
+    } catch (error) {
+      console.error('Failed to fetch dashboard stats:', error);
+      return c.json({ error: 'Internal server error' }, 500);
+    }
+  }
+};

--- a/apps/server/src/interface/controllers/formController.ts
+++ b/apps/server/src/interface/controllers/formController.ts
@@ -3,6 +3,7 @@ import { container } from '@/infrastructure/container';
 import { Form } from '@/domain/entities/Form';
 import { Slug } from '@/domain/value-objects/Slug';
 import { randomUUID } from 'node:crypto';
+import { ApiKeyGenerator } from '@/shared/utils/ApiKeyGenerator';
 
 export const formController = {
   listForms: async (c: Context) => {
@@ -18,6 +19,7 @@ export const formController = {
       return { 
         ...props, 
         slug: props.slug.getValue(),
+        publicId: props.publicId,
         responses: 0,
         rating: null,
         completion: 0
@@ -44,6 +46,7 @@ export const formController = {
       userId,
       name,
       slug: Slug.create(slug),
+      publicId: ApiKeyGenerator.generatePublicId('frm'),
       description,
       isActive: true,
     });
@@ -143,6 +146,7 @@ export const formController = {
       userId,
       name: `${originalProps.name} (Copie)`,
       slug: Slug.create(newSlugValue),
+      publicId: ApiKeyGenerator.generatePublicId('frm'),
       description: originalProps.description,
       thankYouMessage: originalProps.thankYouMessage,
       config: originalProps.config,

--- a/apps/server/src/interface/controllers/publicReviewController.ts
+++ b/apps/server/src/interface/controllers/publicReviewController.ts
@@ -13,11 +13,23 @@ export const publicReviewController = {
 
     const limit = parseInt(c.req.query('limit') || '10', 10);
     const minRating = parseInt(c.req.query('minRating') || '0', 10);
+    const publicId = c.req.query('formId');
+
+    if (!publicId) {
+      return c.json({ error: 'Missing formId query parameter' }, 400);
+    }
 
     try {
-      const testimonials = await container.testimonialRepository.findApprovedByUser(userId, {
+      // Resolve internal ID from public ID
+      const form = await container.formRepository.findByPublicId(publicId);
+      if (!form || form.userId !== userId) {
+        return c.json({ error: 'Form not found or invalid public ID' }, 404);
+      }
+
+      const testimonials = await container.testimonialRepository.findApprovedByUser(userId as string, {
         limit: Math.min(limit, 50), // Cap at 50 for performance
-        minRating: minRating > 0 ? minRating : undefined
+        minRating: minRating > 0 ? minRating : undefined,
+        formId: form.id
       });
 
       return c.json({

--- a/apps/server/src/interface/routes/dashboard.ts
+++ b/apps/server/src/interface/routes/dashboard.ts
@@ -1,0 +1,35 @@
+import { OpenAPIHono, createRoute, z } from '@hono/zod-openapi';
+import { isAuthenticated } from '../../shared/middlewares/auth';
+import { dashboardController } from '../controllers/dashboardController';
+
+export const dashboardRouter = new OpenAPIHono();
+
+// Apply Authentication protection
+dashboardRouter.use('*', isAuthenticated);
+
+const getStatsRoute = createRoute({
+  method: 'get',
+  path: '/stats',
+  summary: 'Get dashboard statistics for the current user',
+  tags: ['Dashboard'],
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            totalReviews: z.number(),
+            averageRating: z.number(),
+            uniqueRespondents: z.number(),
+            completionRate: z.number(),
+          })
+        }
+      },
+      description: 'Dashboard statistics'
+    },
+    401: {
+      description: 'Unauthorized'
+    }
+  }
+});
+
+dashboardRouter.openapi(getStatsRoute, dashboardController.getStats);

--- a/apps/server/src/interface/routes/public.ts
+++ b/apps/server/src/interface/routes/public.ts
@@ -40,6 +40,14 @@ const getReviewsRoute = createRoute({
         },
         example: 'rk_pk_live_...',
       }),
+      formId: z.string().openapi({
+        param: {
+          name: 'formId',
+          in: 'query',
+          required: true,
+        },
+        example: 'rk_frm_live_abc123...',
+      }),
     }),
     headers: z.object({
       'x-api-key': z.string().optional().openapi({

--- a/apps/server/src/shared/utils/ApiKeyGenerator.ts
+++ b/apps/server/src/shared/utils/ApiKeyGenerator.ts
@@ -18,4 +18,13 @@ export class ApiKeyGenerator {
   public static isSecretKey(key: string): boolean {
     return key.startsWith('rk_sk_');
   }
+
+  /**
+   * Generates a public ID for a resource (e.g., rk_frm_...).
+   */
+  public static generatePublicId(prefix: string, environment: 'live' | 'test' = 'live'): string {
+    const fullPrefix = `rk_${prefix}_${environment}_`;
+    const randomPart = randomBytes(12).toString('hex'); // Shorter than API keys
+    return `${fullPrefix}${randomPart}`;
+  }
 }

--- a/apps/server/tests/integration/repositories/FormRepository.test.ts
+++ b/apps/server/tests/integration/repositories/FormRepository.test.ts
@@ -26,6 +26,7 @@ describe("DrizzleFormRepository Integration", () => {
       userId: userId,
       name: "Contact",
       slug: Slug.create("contact"),
+      publicId: "rk_frm_live_contact",
       config: { title: "Contact Us" }
     });
 
@@ -37,8 +38,8 @@ describe("DrizzleFormRepository Integration", () => {
   });
 
   it("should find forms by user ID", async () => {
-    const f1 = new Form({ id: crypto.randomUUID(), userId: userId, name: "F1", slug: Slug.create("f1"), config: {} });
-    const f2 = new Form({ id: crypto.randomUUID(), userId: userId, name: "F2", slug: Slug.create("f2"), config: {} });
+    const f1 = new Form({ id: crypto.randomUUID(), userId: userId, name: "F1", slug: Slug.create("f1"), publicId: "rk_frm_live_f1", config: {} });
+    const f2 = new Form({ id: crypto.randomUUID(), userId: userId, name: "F2", slug: Slug.create("f2"), publicId: "rk_frm_live_f2", config: {} });
 
     await repository.save(f1);
     await repository.save(f2);
@@ -53,6 +54,7 @@ describe("DrizzleFormRepository Integration", () => {
       userId: userId,
       name: "Survey",
       slug: Slug.create("survey"),
+      publicId: "rk_frm_live_survey",
       config: { steps: 1 }
     });
 
@@ -66,12 +68,30 @@ describe("DrizzleFormRepository Integration", () => {
   });
 
   it("should delete a form", async () => {
-    const form = new Form({ id: crypto.randomUUID(), userId: userId, name: "D", slug: Slug.create("d"), config: {} });
+    const form = new Form({ id: crypto.randomUUID(), userId: userId, name: "D", slug: Slug.create("d"), publicId: "rk_frm_live_d", config: {} });
 
     await repository.save(form);
     await repository.delete(form.id);
 
     const found = await repository.findById(form.id);
     expect(found).toBeNull();
+  });
+
+  it("should find a form by its public ID", async () => {
+    const publicId = "rk_frm_live_findme";
+    const form = new Form({
+      id: crypto.randomUUID(),
+      userId: userId,
+      name: "Find Me",
+      slug: Slug.create("find-me"),
+      publicId,
+      config: {}
+    });
+
+    await repository.save(form);
+    const found = await repository.findByPublicId(publicId);
+    
+    expect(found).not.toBeNull();
+    expect(found?.getName()).toBe("Find Me");
   });
 });

--- a/apps/server/tests/unit/domain/EdgeCases.test.ts
+++ b/apps/server/tests/unit/domain/EdgeCases.test.ts
@@ -20,6 +20,7 @@ describe("Domain Hardening Edge Cases", () => {
         userId: "u1",
         name: "Form",
         slug: Slug.create("form"),
+        publicId: "rk_frm_live_f1",
         config: {
           styles: { color: "black", margin: 10 }
         }
@@ -53,6 +54,7 @@ describe("Domain Hardening Edge Cases", () => {
         userId: "u1",
         name: "Test",
         slug: Slug.create("test"),
+        publicId: "rk_frm_live_f1",
         config: { theme: "dark" }
       });
 

--- a/apps/server/tests/unit/domain/entities/Form.test.ts
+++ b/apps/server/tests/unit/domain/entities/Form.test.ts
@@ -9,6 +9,7 @@ describe("Form Entity", () => {
     userId: "user-1",
     name: "Contact Form",
     slug: validSlug,
+    publicId: "rk_frm_live_test123",
   };
 
   describe("Creation", () => {


### PR DESCRIPTION
- Add  column to forms table in the database schema.
- Update [Form](cci:2://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:18:0-98:1) domain entity and repository to support public IDs.
- Implement  format for public identifiers, decoupling the API from raw database UUIDs.
- Update public reviews API to resolve forms via their public ID.
- Add 'Copy Form ID' functionality to the dashboard (Table and Share Modal).
- Update unit and integration tests to support mandatory public IDs.