### PR TITLE
fix(auth): prevent IDOR on form batch operations

### DIFF
--- a/apps/server/src/domain/repositories/FormRepository.ts
+++ b/apps/server/src/domain/repositories/FormRepository.ts
@@ -5,6 +5,7 @@ export interface FormRepository {
   findBySlug(slug: string): Promise<Form | null>;
   findByPublicId(publicId: string): Promise<Form | null>;
   findByUser(userId: string): Promise<Form[]>;
+  findByIdsAndUser(ids: string[], userId: string): Promise<Form[]>;
   save(form: Form): Promise<void>;
   update(form: Form): Promise<void>;
   delete(id: string): Promise<void>;

--- a/apps/server/src/infrastructure/repositories/DrizzleFormRepository.ts
+++ b/apps/server/src/infrastructure/repositories/DrizzleFormRepository.ts
@@ -37,6 +37,17 @@ export class DrizzleFormRepository implements FormRepository {
     return rows.map(row => this.mapToDomain(row));
   }
 
+  async findByIdsAndUser(ids: string[], userId: string): Promise<Form[]> {
+    if (!ids || ids.length === 0) return [];
+    
+    const { inArray } = await import('drizzle-orm');
+    const rows = await this.db.select()
+      .from(forms)
+      .where(and(inArray(forms.id, ids), eq(forms.userId, userId)));
+      
+    return rows.map(row => this.mapToDomain(row));
+  }
+
   async save(form: Form): Promise<void> {
     const props = form.getProps();
     await this.db.insert(forms).values({

--- a/apps/server/src/interface/controllers/formController.ts
+++ b/apps/server/src/interface/controllers/formController.ts
@@ -201,9 +201,11 @@ export const formController = {
     }
 
     try {
-      // Security check: ensure all forms belong to the user
-      // For simplicity in this demo, we assume the IDs are valid, 
-      // but in production we'd verify ownership for each ID.
+      const owned = await container.formRepository.findByIdsAndUser(ids, userId);
+      if (owned.length !== ids.length) {
+        return c.json({ error: 'Forbidden: one or more forms do not belong to you' }, 403);
+      }
+
       await container.formRepository.batchUpdateStatus(ids, isActive);
       return c.json({ success: true, isActive });
     } catch (err: any) {
@@ -224,6 +226,11 @@ export const formController = {
     }
 
     try {
+      const owned = await container.formRepository.findByIdsAndUser(ids, userId);
+      if (owned.length !== ids.length) {
+        return c.json({ error: 'Forbidden: one or more forms do not belong to you' }, 403);
+      }
+
       await container.formRepository.batchDelete(ids);
       return c.json({ success: true });
     } catch (err: any) {

--- a/apps/server/tests/integration/repositories/FormRepository.test.ts
+++ b/apps/server/tests/integration/repositories/FormRepository.test.ts
@@ -94,4 +94,34 @@ describe("DrizzleFormRepository Integration", () => {
     expect(found).not.toBeNull();
     expect(found?.getName()).toBe("Find Me");
   });
+
+  it("should find forms by multiple IDs and user ID", async () => {
+    const f1 = new Form({ id: crypto.randomUUID(), userId: userId, name: "F1", slug: Slug.create("f1-multi"), publicId: "rk_frm_live_f1m", config: {} });
+    const f2 = new Form({ id: crypto.randomUUID(), userId: userId, name: "F2", slug: Slug.create("f2-multi"), publicId: "rk_frm_live_f2m", config: {} });
+    
+    const otherUserId = crypto.randomUUID();
+    await testDb.insert(schema.users).values({
+      id: otherUserId,
+      email: "other2@example.com",
+      name: "Other User 2",
+      emailVerified: true,
+      isSystemAdmin: false
+    });
+    
+    const f3 = new Form({ id: crypto.randomUUID(), userId: otherUserId, name: "F3", slug: Slug.create("f3-multi"), publicId: "rk_frm_live_f3m", config: {} });
+
+    await repository.save(f1);
+    await repository.save(f2);
+    await repository.save(f3);
+
+    const found = await repository.findByIdsAndUser([f1.id, f2.id, f3.id], userId);
+    expect(found).toHaveLength(2);
+    const foundIds = found.map(f => f.id);
+    expect(foundIds).toContain(f1.id);
+    expect(foundIds).toContain(f2.id);
+    expect(foundIds).not.toContain(f3.id);
+    
+    const missing = await repository.findByIdsAndUser([f1.id], otherUserId);
+    expect(missing).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a P0-2 IDOR vulnerability on form batch operations by enforcing strict ownership validation.

Closes #<!-- issue number -->

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

- Updated FormRepository interface with a new findByIdsAndUser method to fetch forms filtered by user ID
- Implemented findByIdsAndUser in DrizzleFormRepository using an optimized inArray query
- Added ownership checks in formController batchToggleStatus and batchDeleteForms to return 403 Forbidden if the requested IDs do not belong to the authenticated user
- Added an integration test in FormRepository.test.ts to guarantee the ID filtering works securely at the database level

---

## How to test

1. Sign in as User A and create a form
2. Sign in as User B and attempt to call the batchToggleStatus or batchDeleteForms API endpoints using the form ID of User A
3. Verify that the server rejects the request with a 403 Forbidden status code
4. Run the integration tests locally using bun test tests/integration/repositories/FormRepository.test.ts to verify the underlying database logic

---

## Checklist

- [x] My code follows the project conventions
- [x] I tested this locally
- [ ] I updated the documentation if needed
- [x] No console.log or debug code left
- [x] No .env or secrets committed
