### PR TITLE
fix(db): apply allowlist to dynamic sorting in findByFormId

### DIFF
--- a/apps/server/src/infrastructure/repositories/DrizzleTestimonialRepository.ts
+++ b/apps/server/src/infrastructure/repositories/DrizzleTestimonialRepository.ts
@@ -126,8 +126,10 @@ export class DrizzleTestimonialRepository implements TestimonialRepository {
     const sortField = options?.sort;
     const sortOrder = options?.order || 'desc';
     
-    if (sortField) {
-      const column = (testimonials as any)[sortField] || testimonials.createdAt;
+    const allowedSortFields = ['createdAt', 'rating', 'position', 'status', 'authorName'];
+    
+    if (sortField && allowedSortFields.includes(sortField)) {
+      const column = (testimonials as any)[sortField];
       query.orderBy(sortOrder === 'desc' ? desc(column) : asc(column));
     } else {
       // Default order: position ASC (manual order), then createdAt DESC (newest first)


### PR DESCRIPTION
## 📝 Description
This PR addresses the security vulnerability **P1-2 (Tri dynamique sans allowlist)** in `findByFormId`. Previously, user-provided sort values from the request URL were injected directly into Drizzle's `orderBy` clause, exposing the database to arbitrary column lookups.

## 🛠️ Changes Made
- Introduced a hardcoded `allowedSortFields` array containing the permitted sorting keys (`createdAt`, `rating`, `position`, `status`, `authorName`).
- Invalid strings now trigger the baseline fallback sorting.

## ✅ Verification
- Compile check passed.
