### PR TITLE
refactor(api): DRY extract userId logic across controllers

### DIFF
--- a/apps/server/src/interface/controllers/dashboardController.ts
+++ b/apps/server/src/interface/controllers/dashboardController.ts
@@ -1,9 +1,10 @@
 import type { Context } from 'hono';
+import { getUserIdFromContext } from '@/shared/utils/auth';
 import { container } from '@/infrastructure/container';
 
 export const dashboardController = {
   getStats: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);

--- a/apps/server/src/interface/controllers/formController.ts
+++ b/apps/server/src/interface/controllers/formController.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono';
+import { getUserIdFromContext } from '@/shared/utils/auth';
 import { container } from '@/infrastructure/container';
 import { Form } from '@/domain/entities/Form';
 import { Slug } from '@/domain/value-objects/Slug';
@@ -7,7 +8,7 @@ import { ApiKeyGenerator } from '@/shared/utils/ApiKeyGenerator';
 
 export const formController = {
   listForms: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);
@@ -35,7 +36,7 @@ export const formController = {
   },
 
   createForm: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);
@@ -72,7 +73,7 @@ export const formController = {
   },
 
   getFormDetails: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const formId = c.req.param('id');
 
     if (!userId || !formId) {
@@ -98,7 +99,7 @@ export const formController = {
   },
 
   deleteForm: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const formId = c.req.param('id');
 
     if (!userId || !formId) {
@@ -115,7 +116,7 @@ export const formController = {
   },
 
   updateForm: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const formId = c.req.param('id');
     const body = await c.req.json();
     const { name, description, config, isActive } = body;
@@ -141,7 +142,7 @@ export const formController = {
   },
 
   toggleFormStatus: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const formId = c.req.param('id');
 
     if (!userId || !formId) {
@@ -161,7 +162,7 @@ export const formController = {
   },
 
   duplicateForm: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const formId = c.req.param('id');
 
     if (!userId || !formId) {
@@ -195,7 +196,7 @@ export const formController = {
   },
 
   batchToggleStatus: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);
     }
@@ -220,7 +221,7 @@ export const formController = {
   },
 
   batchDeleteForms: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     if (!userId) {
       return c.json({ error: 'Unauthorized' }, 401);
     }
@@ -245,7 +246,7 @@ export const formController = {
   },
 
   getFormStats: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const formId = c.req.param('id');
 
     if (!userId || !formId) {
@@ -263,7 +264,7 @@ export const formController = {
   },
 
   getFormTestimonials: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const formId = c.req.param('id');
     const page = parseInt(c.req.query('page') || '1', 10);
     const limit = 10;

--- a/apps/server/src/interface/controllers/testimonialController.ts
+++ b/apps/server/src/interface/controllers/testimonialController.ts
@@ -1,9 +1,10 @@
 import type { Context } from 'hono';
+import { getUserIdFromContext } from '@/shared/utils/auth';
 import { container } from '@/infrastructure/container';
 
 export const testimonialController = {
   updateStatus: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const id = c.req.param('id');
     const { status } = await c.req.json();
 
@@ -32,7 +33,7 @@ export const testimonialController = {
   },
 
   deleteTestimonial: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const id = c.req.param('id');
 
     if (!userId || !id) {
@@ -49,7 +50,7 @@ export const testimonialController = {
   },
 
   batchUpdateStatus: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const { ids, status } = await c.req.json();
 
     if (!userId || !Array.isArray(ids) || ids.length === 0 || !status) {
@@ -66,7 +67,7 @@ export const testimonialController = {
   },
 
   batchDelete: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const { ids } = await c.req.json();
 
     if (!userId || !Array.isArray(ids) || ids.length === 0) {
@@ -83,7 +84,7 @@ export const testimonialController = {
   },
 
   reorderTestimonials: async (c: Context) => {
-    const userId = c.get('userId') || (c.get('session') as any)?.user?.id;
+    const userId = getUserIdFromContext(c);
     const { positions } = await c.req.json(); // Array of { id: string, position: number }
 
     if (!userId || !Array.isArray(positions)) {

--- a/apps/server/src/shared/utils/auth.ts
+++ b/apps/server/src/shared/utils/auth.ts
@@ -1,0 +1,9 @@
+import type { Context } from 'hono';
+
+/**
+ * Extracts the authenticated user ID from the expected Hono Context scopes.
+ * Handles both API contexts and Session contexts.
+ */
+export const getUserIdFromContext = (c: Context): string | undefined => {
+  return c.get('userId') || (c.get('session') as any)?.user?.id;
+};


### PR DESCRIPTION
## 📝 Description
This PR resolves **P1-3 (Pattern c.get('userId') dupliqué 15+ fois)**. The exact same complex conditional lookup for the user's ID was repeated exactly 17 times throughout the controllers layer.

## 🛠️ Changes Made
- **Shared Utils**: Created `apps/server/src/shared/utils/auth.ts` with a `getUserIdFromContext` helper.
- **Controllers**: Cleaned up the first lines of 17 route handlers across `formController`, `testimonialController`, and `dashboardController` by using this new helper.

## ✅ Verification
- Strict TS compilation passed successfully against `Hono` context endpoints.