### PR TITLE
refactor(domain): enforce Form entity encapsulation

### DIFF
--- a/apps/server/src/domain/entities/Form.ts
+++ b/apps/server/src/domain/entities/Form.ts
@@ -108,6 +108,16 @@ export class Form {
     this.updatedAt = new Date();
   }
 
+  public updateDescription(description: string): void {
+    this.description = description;
+    this.updatedAt = new Date();
+  }
+
+  public updateIsActive(isActive: boolean): void {
+    this.isActive = isActive;
+    this.updatedAt = new Date();
+  }
+
   public toggleActive(): void {
     this.isActive = !this.isActive;
     this.updatedAt = new Date();

--- a/apps/server/src/interface/controllers/formController.ts
+++ b/apps/server/src/interface/controllers/formController.ts
@@ -131,9 +131,9 @@ export const formController = {
     }
 
     if (name) form.updateName(name);
-    if (description !== undefined) (form as any).description = description; // Using as any if property is private but needed
+    if (description !== undefined) form.updateDescription(description);
     if (config) form.updateConfig(config);
-    if (isActive !== undefined) (form as any).isActive = isActive;
+    if (isActive !== undefined) form.updateIsActive(isActive);
 
     await container.formRepository.update(form);
     


### PR DESCRIPTION
## 📝 Description
This PR resolves **P1-4 (Bypass de l'encapsulation domaine via [(form as any)](cci:2://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:40:0-188:1))**. 
Previously, the `formController` bypassed TypeScript access modifiers using [(form as any).description = ...](cci:2://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:40:0-188:1) and [(form as any).isActive = ...](cci:2://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:40:0-188:1) because the [Form](cci:2://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:40:0-188:1) entity lacked proper update methods for these private fields.

## 🛠️ Changes Made
- **Domain Layer ([Form.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:0:0-0:0))**: Added proper setter methods [updateDescription(string)](cci:1://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:110:2-113:3) and [updateIsActive(boolean)](cci:1://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/entities/Form.ts:115:2-118:3) which update the internal state and trigger `updatedAt` renewal.
- **Controller Layer ([formController.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/interface/controllers/formController.ts:0:0-0:0))**: Replaced the dirty `as any` casts with calls to the dedicated domain methods.

## ✅ Verification
- Domain logic adheres strictly to DDD encapsulation.
- TypeScript builds perfectly (`tsc --noEmit` exit code 0).
