### PR TITLE
fix(cors): replace hardcoded docker ID with allowed origins env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/$
 
 # Auth
 BETTER_AUTH_SECRET=your_super_secret_auth_key
+BETTER_AUTH_URL=http://localhost:3000/api/auth
 
 # Admin Initial Credentials
 ADMIN_EMAIL=admin@reviewskits.com

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,8 +14,12 @@ import { testimonialsRouter } from './interface/routes/testimonials';
 const app = new OpenAPIHono();
 
 // Enable CORS
+const allowedOrigins = process.env.CORS_ALLOWED_ORIGINS 
+  ? process.env.CORS_ALLOWED_ORIGINS.split(',').map(o => o.trim())
+  : ['http://localhost:5174', 'http://localhost:5180', 'http://localhost:3000'];
+
 app.use('*', cors({
-  origin: ['http://172.20.0.1:5180', 'http://localhost:5174', 'http://localhost:5180', 'http://localhost:3000'], // Allow frontend and self (swagger)
+  origin: allowedOrigins,
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   allowHeaders: ['Content-Type', 'Authorization', 'x-api-key'],
   exposeHeaders: ['Content-Length', 'Set-Cookie'],


### PR DESCRIPTION
## 📝 Description
This PR resolves **P1-5 (IP Docker Gateway hardcodée dans la configuration CORS)**. The previous CORS configuration allowed a hardcoded IP (`http://172.20.0.1:5180`), linking the codebase to a specific local Docker topology that is unsuitable for production or team synchronization.

## 🛠️ Changes Made
- Introduced a dynamic fallback utilizing the `CORS_ALLOWED_ORIGINS` environment variable.
- Supported comma-separated origins.
- Safely cascaded to `['http://localhost:5174', 'http://localhost:5180', 'http://localhost:3000']` when the env var is missing to preserve fluid developer experience locally.

## ✅ Verification
- Typecheck strictly enforced, compiling transparently.
