### PR TITLE
fix(api): rename misleading 'type' field to 'source' in public reviews

### DIFF
--- a/apps/server/src/interface/controllers/publicReviewController.ts
+++ b/apps/server/src/interface/controllers/publicReviewController.ts
@@ -53,7 +53,7 @@ export const publicReviewController = {
             authorTitle: props.authorTitle,
             authorUrl: props.authorUrl,
             createdAt: props.createdAt,
-            type: props.source
+            source: props.source
           };
         })
       });

--- a/apps/server/src/interface/routes/public.ts
+++ b/apps/server/src/interface/routes/public.ts
@@ -73,7 +73,7 @@ const getReviewsRoute = createRoute({
               authorTitle: z.string().optional(),
               authorUrl: z.string().optional(),
               createdAt: z.date().or(z.string()),
-              type: z.string(),
+              source: z.string(),
             })),
           }),
         },


### PR DESCRIPTION
## 📝 Description
This PR resolves **P2-1 (Champ type mappé sur source (sémantique incorrecte))**. The public API was exposing the testimonial `source` under the key `type`, which is semantically incorrect and inconsistent with the rest of the application.

## 🛠️ Changes Made
- **Controller**: Renamed `type` to `source` in the JSON response mapping.
- **Router/OpenAPI**: Updated the Zod schema and Swagger documentation to reflect the correct field name.

## ✅ Verification
- TypeScript verification passed.
- API response now matches domain terminology.
