### PR TITLE
feat(stats): implement real form completion rate calculation

### DIFF
--- a/apps/server/src/domain/repositories/FormRepository.ts
+++ b/apps/server/src/domain/repositories/FormRepository.ts
@@ -12,4 +12,5 @@ export interface FormRepository {
   batchUpdateStatus(ids: string[], isActive: boolean): Promise<void>;
   batchDelete(ids: string[]): Promise<void>;
   incrementVisits(formId: string): Promise<void>;
+  getVisitsByFormIds(formIds: string[]): Promise<Map<string, number>>;
 }

--- a/apps/server/src/infrastructure/repositories/DrizzleFormRepository.ts
+++ b/apps/server/src/infrastructure/repositories/DrizzleFormRepository.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, sql, inArray, sum } from 'drizzle-orm';
 import type { BunSQLDatabase } from 'drizzle-orm/bun-sql';
 import * as schema from '../database/schema';
 import { forms, formVisits } from '../database/schema';
@@ -107,6 +107,26 @@ export class DrizzleFormRepository implements FormRepository {
         target: [formVisits.formId, formVisits.date],
         set: { visits: sql`${formVisits.visits} + 1`, updatedAt: new Date() }
       });
+  }
+
+  async getVisitsByFormIds(formIds: string[]): Promise<Map<string, number>> {
+    const resultMap = new Map<string, number>();
+    if (!formIds || formIds.length === 0) return resultMap;
+
+    const results = await this.db
+      .select({
+        formId: formVisits.formId,
+        totalVisits: sum(formVisits.visits),
+      })
+      .from(formVisits)
+      .where(inArray(formVisits.formId, formIds))
+      .groupBy(formVisits.formId);
+
+    results.forEach((r) => {
+      resultMap.set(r.formId, Number(r.totalVisits || 0));
+    });
+
+    return resultMap;
   }
 
   private mapToDomain(row: any): Form {

--- a/apps/server/src/interface/controllers/formController.ts
+++ b/apps/server/src/interface/controllers/formController.ts
@@ -17,18 +17,28 @@ export const formController = {
     const forms = await container.formRepository.findByUser(userId);
     
     const formIds = forms.map(f => f.getProps().id);
-    const statsMap = await container.testimonialRepository.getBasicStatsByFormIds(formIds);
+    const [statsMap, visitsMap] = await Promise.all([
+      container.testimonialRepository.getBasicStatsByFormIds(formIds),
+      container.formRepository.getVisitsByFormIds(formIds)
+    ]);
 
     const formsWithStats = forms.map(f => {
       const props = f.getProps();
       const stats = statsMap.get(props.id) || { totalReviews: 0, averageRating: 0 };
+      const visits = visitsMap.get(props.id) || 0;
+      
+      let completion = 0;
+      if (visits > 0) {
+        completion = Math.min(100, Math.round((stats.totalReviews / visits) * 100));
+      }
+
       return { 
         ...props, 
         slug: props.slug.getValue(),
         publicId: props.publicId,
         responses: stats.totalReviews,
         rating: stats.averageRating,
-        completion: 100 // Placeholder for now
+        completion
       };
     });
     
@@ -87,14 +97,23 @@ export const formController = {
     }
 
     const props = form.getProps();
-    const stats = await container.testimonialRepository.getStatsByFormId(props.id);
+    const [stats, visitsMap] = await Promise.all([
+      container.testimonialRepository.getStatsByFormId(props.id),
+      container.formRepository.getVisitsByFormIds([props.id])
+    ]);
     
+    const visits = visitsMap.get(props.id) || 0;
+    let completion = 0;
+    if (visits > 0) {
+      completion = Math.min(100, Math.round((stats.totalReviews / visits) * 100));
+    }
+
     return c.json({ 
       ...props, 
       slug: props.slug.getValue(),
       responses: stats.totalReviews,
       rating: stats.averageRating,
-      completion: 100
+      completion
     });
   },
 


### PR DESCRIPTION
## 📝 Description
This PR resolves **P2-2 (completion: 100 hardcodé — données trompeuses pour l'utilisateur)**. Previously, all forms showed a 100% completion rate regardless of actual performance.

## 🛠️ Changes Made
- **Domain/Infra**: Added support for retrieving aggregated visit counts from the `form_visits` analytics table.
- **Controller**: Replaced placeholders with a calculated metric: `Math.round((responses / global_visits) * 100)`.

## ✅ Verification
- Verified with TypeScript typecheck.
- Enhanced the value of the dashboard for end-users by providing real engagement data.
