### PR TITLE
fix: add ownership check to reorderTestimonials to prevent privilege …

### DIFF
--- a/apps/server/src/interface/controllers/testimonialController.ts
+++ b/apps/server/src/interface/controllers/testimonialController.ts
@@ -91,6 +91,12 @@ export const testimonialController = {
       return c.json({ error: 'Unauthorized or invalid data' }, 401);
     }
 
+    const ids = positions.map((p: any) => p.id);
+    const owned = await container.testimonialRepository.findByIdsAndUser(ids, userId);
+    if (owned.length !== ids.length) {
+      return c.json({ error: 'Forbidden: one or more testimonials do not belong to you' }, 403);
+    }
+
     await container.testimonialRepository.updatePositions(positions);
     return c.json({ success: true });
   }

--- a/apps/server/tests/integration/controllers/testimonialController.test.ts
+++ b/apps/server/tests/integration/controllers/testimonialController.test.ts
@@ -139,4 +139,45 @@ describe("Testimonial Controller Integration", () => {
     const updated1 = await container.testimonialRepository.findById(t1.getId());
     expect(updated1?.getStatus()).toBe("pending"); // Should NOT have changed
   });
+
+  it("should reject reordering if user does not own all testimonials", async () => {
+    const otherUserId = crypto.randomUUID();
+    await testDb.execute(sql`
+      INSERT INTO "users" (id, name, email) 
+      VALUES (${otherUserId}, 'Other User Reorder', 'other-reorder@example.com')
+    `);
+
+    const t1 = new Testimonial({ id: crypto.randomUUID(), userId: otherUserId, content: "Not Mine", authorName: "Other", status: "pending", source: "api" });
+    await container.testimonialRepository.save(t1);
+
+    const res = await testimonialsRouter.request("/reorder", {
+      method: "POST",
+      body: JSON.stringify({ positions: [{ id: t1.getId(), position: 1 }] }),
+      headers: authHeaders
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("should allow reordering if user owns all testimonials", async () => {
+    const t1 = new Testimonial({ id: crypto.randomUUID(), userId, content: "Mine 1", authorName: "Me", status: "pending", source: "api" });
+    const t2 = new Testimonial({ id: crypto.randomUUID(), userId, content: "Mine 2", authorName: "Me", status: "pending", source: "api" });
+    await container.testimonialRepository.save(t1);
+    await container.testimonialRepository.save(t2);
+
+    const res = await testimonialsRouter.request("/reorder", {
+      method: "POST",
+      body: JSON.stringify({ 
+        positions: [
+          { id: t1.getId(), position: 2 },
+          { id: t2.getId(), position: 1 }
+        ] 
+      }),
+      headers: authHeaders
+    });
+
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(data.success).toBe(true);
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Adds an ownership check in the [reorderTestimonials](cci:1://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/interface/controllers/testimonialController.ts:85:2-101:3) controller action to ensure users can only reorder testimonials they own, fixing a privilege escalation vulnerability.

Closes #P0-1

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

- Modified [testimonialController.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/interface/controllers/testimonialController.ts:0:0-0:0) to implement a validation step in [reorderTestimonials](cci:1://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/interface/controllers/testimonialController.ts:85:2-101:3) using [findByIdsAndUser](cci:1://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/domain/repositories/TestimonialRepository.ts:5:2-5:73).
- Added integration tests in [testimonialController.test.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/tests/integration/controllers/testimonialController.test.ts:0:0-0:0) to verify both the fix (unauthorized reordering returns 403) and legitimate usage (owner can reorder).

---

## How to test

1. Ensure the local infrastructure is running.
2. Run the specific integration tests for testimonials:
   ```bash
   bun test apps/server/tests/integration/controllers/testimonialController.test.ts
