### PR TITLE
fix: validate BETTER_AUTH_SECRET to prevent silent failures

### DIFF
--- a/apps/server/src/infrastructure/auth/auth.ts
+++ b/apps/server/src/infrastructure/auth/auth.ts
@@ -4,6 +4,11 @@ import { bearer } from "better-auth/plugins";
 import { db } from "../database/db";
 import * as schema from "../database/schema";
 
+const secret = process.env.BETTER_AUTH_SECRET;
+if (!secret) {
+  throw new Error("BETTER_AUTH_SECRET environment variable is required for session encryption. Please set it in your .env file.");
+}
+
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg",
@@ -59,7 +64,7 @@ export const auth = betterAuth({
     },
   },
   // Secret for session encryption/signing
-  secret: process.env.BETTER_AUTH_SECRET,
+  secret,
   // Base URL for auth endpoints
   baseURL: process.env.BETTER_AUTH_URL || "http://localhost:3000/api/auth",
   trustedOrigins: [


### PR DESCRIPTION
## What does this PR do?

Adds a mandatory validation for the `BETTER_AUTH_SECRET` environment variable during server startup. This prevents the application from starting with an insecure or missing configuration, which could lead to silent authentication failures.

Closes #P0-2

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

- Modified [apps/server/src/infrastructure/auth/auth.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/infrastructure/auth/auth.ts:0:0-0:0) to check for `BETTER_AUTH_SECRET` before initializing the auth service.
- The application now throws a descriptive error if the secret is missing.

---

## How to test

1. Temporarily comment out or rename `BETTER_AUTH_SECRET` in your [.env](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/.env:0:0-0:0) file.
2. Attempt to start the server: `bun run dev` (dans apps/server).
3. Verify that the server crashes with the message: `Error: BETTER_AUTH_SECRET environment variable is required for session encryption. Please set it in your .env file.`
4. Restore the variable and verify the server starts correctly.

---

## Checklist

- [x] My code follows the project conventions
- [x] I tested this locally
- [ ] I updated the documentation if needed
- [x] No console.log or debug code left
- [x] No `.env` or secrets committed
