### PR TITLE
fix: validate DATABASE_URL to provide clear error on startup

### DIFF
--- a/apps/server/src/infrastructure/database/db.ts
+++ b/apps/server/src/infrastructure/database/db.ts
@@ -1,4 +1,9 @@
 import { drizzle } from 'drizzle-orm/bun-sql';
 import * as schema from './schema';
 
-export const db = drizzle(process.env.DATABASE_URL!, { schema });
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL environment variable is required. Please set it in your .env file.");
+}
+
+export const db = drizzle(databaseUrl, { schema });


### PR DESCRIPTION
## What does this PR do?

Adds a mandatory check for the `DATABASE_URL` environment variable. Previously, the application used a non-null assertion (`!`) which would lead to an implicit crash. It now throws a descriptive error if the variable is missing.

Closes #P0-3

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

- Modified [apps/server/src/infrastructure/database/db.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/infrastructure/database/db.ts:0:0-0:0) to implement a guard for `DATABASE_URL`.
- Replaced the unsafe non-null assertion with a proper validation check.

---

## How to test

1. Temporarily unset `DATABASE_URL` in your environment or comment it out in [.env](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/.env:0:0-0:0).
2. Start the server (e.g., `bun run dev` dans apps/server).
3. Verify that the application fails with: `Error: DATABASE_URL environment variable is required. Please set it in your .env file.`

---

## Checklist

- [x] My code follows the project conventions
- [x] I tested this locally
- [ ] I updated the documentation if needed
- [x] No console.log or debug code left
- [x] No `.env` or secrets committed
