### PR TITLE
fix: resolve database errors in rate limiter and fix related type issues

### DIFF
--- a/apps/server/src/infrastructure/auth/auth.ts
+++ b/apps/server/src/infrastructure/auth/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer } from "better-auth/plugins";
+import { sql } from "drizzle-orm";
 import { db } from "../database/db";
 import * as schema from "../database/schema";
 
@@ -48,10 +49,15 @@ export const auth = betterAuth({
             }
           }
 
-          const userCount = await db.select().from(schema.users);
-          if (userCount.length === 0) {
-            userData.isSystemAdmin = true;
-          }
+          await db.transaction(async (tx) => {
+            const [result] = await tx
+              .select({ count: sql<number>`count(*)` })
+              .from(schema.users);
+            
+            if (result && Number(result.count) === 0) {
+              userData.isSystemAdmin = true;
+            }
+          });
 
           return { data: userData };
         },

--- a/apps/server/src/infrastructure/database/schema.ts
+++ b/apps/server/src/infrastructure/database/schema.ts
@@ -176,3 +176,12 @@ export const webhookLogs = pgTable('webhook_logs', {
   webhookIdx: index('idx_webhook_logs_webhook').on(t.webhookId),
   deliveredIdx: index('idx_webhook_logs_delivered').on(t.delivered),
 }));
+// ═══════════════════════════════════════
+// RATE LIMITING
+// ═══════════════════════════════════════
+
+export const rateLimits = pgTable('rate_limits', {
+  key: text('key').primaryKey(),
+  count: integer('count').notNull().default(0),
+  resetAt: timestamp('reset_at').notNull(),
+});

--- a/apps/server/src/interface/controllers/publicReviewController.ts
+++ b/apps/server/src/interface/controllers/publicReviewController.ts
@@ -4,6 +4,20 @@ import { Testimonial } from '@/domain/entities/Testimonial';
 import { Rating } from '@/domain/value-objects/Rating';
 import { Email } from '@/domain/value-objects/Email';
 import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+const submitReviewSchema = z.object({
+  formId: z.string().min(1, 'formId is required'),
+  content: z.string().min(1, 'content is required').max(5000, 'content is too long (max 5000 characters)'),
+  authorName: z.string().min(1, 'authorName is required').max(100, 'authorName is too long'),
+  authorEmail: z.string().email('Invalid email format').optional().or(z.literal('')),
+  rating: z.union([z.string(), z.number()]).optional(),
+  authorTitle: z.string().max(100).optional(),
+  authorUrl: z.string().url('Invalid URL format').refine(val => val.startsWith('http://') || val.startsWith('https://'), {
+    message: "Only http and https protocols are allowed for authorUrl"
+  }).optional().or(z.literal('')),
+  _honey: z.string().optional()
+});
 
 export const publicReviewController = {
   /**
@@ -53,7 +67,8 @@ export const publicReviewController = {
       });
     } catch (error) {
       console.error('Failed to fetch public reviews:', error);
-      return c.json({ error: 'Internal server error' }, 500);
+      const isProduction = process.env.NODE_ENV === 'production';
+      return c.json({ error: isProduction ? 'Internal server error' : (error instanceof Error ? error.message : 'Internal server error') }, 500);
     }
   },
 
@@ -61,17 +76,14 @@ export const publicReviewController = {
    * Submit a new review (publicly accessible)
    */
   submitReview: async (c: Context) => {
-    const body = await c.req.json() as { 
-      formId: string, 
-      content: string, 
-      authorName: string, 
-      authorEmail?: string, 
-      rating?: string | number, 
-      authorTitle?: string, 
-      authorUrl?: string, 
-      _honey?: string 
-    };
-    const { formId, content, authorName, authorEmail, rating, authorTitle, authorUrl, _honey } = body;
+    const rawBody = await c.req.json().catch(() => ({}));
+    const validation = submitReviewSchema.safeParse(rawBody);
+    
+    if (!validation.success) {
+      return c.json({ error: validation.error.issues[0]?.message || 'Invalid input' }, 400);
+    }
+
+    const { formId, content, authorName, authorEmail, rating, authorTitle, authorUrl, _honey } = validation.data;
 
     // Honeypot check - Spambots usually fill hidden fields
     if (_honey) {
@@ -81,10 +93,6 @@ export const publicReviewController = {
         message: 'Review submitted successfully',
         id: randomUUID()
       }, 201);
-    }
-
-    if (!formId || !content || !authorName) {
-      return c.json({ error: 'Missing required fields: formId, content, authorName' }, 400);
     }
 
     try {
@@ -100,10 +108,10 @@ export const publicReviewController = {
         formId: form.getId(),
         content,
         authorName,
-        rating: rating ? Rating.create(Number(rating)) : undefined,
-        authorEmail: authorEmail ? Email.create(authorEmail) : undefined,
+        rating: (rating !== undefined && rating !== null && rating !== '') ? Rating.create(Number(rating)) : undefined,
+        authorEmail: (authorEmail && authorEmail !== '') ? Email.create(authorEmail) : undefined,
         authorTitle,
-        authorUrl,
+        authorUrl: (authorUrl && authorUrl !== '') ? authorUrl : undefined,
         status: 'pending',
         source: 'form'
       });
@@ -117,7 +125,8 @@ export const publicReviewController = {
       }, 201);
     } catch (error: unknown) {
       console.error('Failed to submit public review:', error);
-      const message = error instanceof Error ? error.message : 'Internal server error';
+      const isProduction = process.env.NODE_ENV === 'production';
+      const message = (isProduction || !(error instanceof Error)) ? 'Internal server error' : error.message;
       return c.json({ error: message }, 500);
     }
   },

--- a/apps/server/src/interface/middlewares/rateLimiter.ts
+++ b/apps/server/src/interface/middlewares/rateLimiter.ts
@@ -1,8 +1,8 @@
 import type { Context, Next } from 'hono';
-
 import { getConnInfo } from 'hono/bun';
-
-const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
+import { sql, eq } from 'drizzle-orm';
+import { db } from '@/infrastructure/database/db';
+import { rateLimits } from '@/infrastructure/database/schema';
 
 export const rateLimiter = (options: { limit: number; windowMs: number }) => {
   return async (c: Context, next: Next) => {
@@ -19,19 +19,38 @@ export const rateLimiter = (options: { limit: number; windowMs: number }) => {
            'unknown';
     }
     
-    const now = Date.now();
-    let record = rateLimitMap.get(ip);
-    
-    // Clean up expired window
-    if (!record || now > record.resetTime) {
-      record = { count: 0, resetTime: now + options.windowMs };
-    }
-    
-    record.count++;
-    rateLimitMap.set(ip, record);
+    const now = new Date();
+    const key = `rl:${ip}`;
+    const windowStart = new Date(now.getTime() + options.windowMs);
 
-    if (record.count > options.limit) {
-      return c.json({ error: 'Too many requests, please try again later.' }, 429);
+    try {
+      // Distributed rate limiting logic
+      const count = await db.transaction(async (tx) => {
+        const [existing] = await tx.select().from(rateLimits).where(eq(rateLimits.key, key)).limit(1);
+        
+        if (!existing || now > existing.resetAt) {
+          const [inserted] = await tx.insert(rateLimits)
+            .values({ key, count: 1, resetAt: windowStart })
+            .onConflictDoUpdate({
+              target: rateLimits.key,
+              set: { count: 1, resetAt: windowStart }
+            })
+            .returning({ count: rateLimits.count });
+          return inserted?.count ?? 1;
+        } else {
+          const [updated] = await tx.update(rateLimits)
+            .set({ count: sql`${rateLimits.count} + 1` })
+            .where(eq(rateLimits.key, key))
+            .returning({ count: rateLimits.count });
+          return updated?.count ?? existing.count + 1;
+        }
+      });
+
+      if (count > options.limit) {
+        return c.json({ error: 'Too many requests, please try again later.' }, 429);
+      }
+    } catch (error) {
+      console.error('Rate limiter database error:', error);
     }
     
     await next();

--- a/apps/server/tests/integration/IntegrationSetup.ts
+++ b/apps/server/tests/integration/IntegrationSetup.ts
@@ -1,6 +1,6 @@
 import { drizzle } from 'drizzle-orm/bun-sql';
 import * as schema from '../../src/infrastructure/database/schema';
-import { sql } from 'drizzle-orm';
+import { sql, eq } from 'drizzle-orm';
 
 // Build DATABASE_URL from environment variables
 const POSTGRES_USER = process.env.POSTGRES_USER || 'postgres';
@@ -27,7 +27,8 @@ export async function clearDatabase() {
     'sessions',
     'accounts',
     'verifications',
-    'users'
+    'users',
+    'rate_limits'
   ];
 
   for (const table of tables) {

--- a/apps/server/tests/integration/security/SecurityChecks.test.ts
+++ b/apps/server/tests/integration/security/SecurityChecks.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import { testDb, clearDatabase } from "../IntegrationSetup";
+import { publicRouter } from "../../../src/interface/routes/public";
+import { container } from "../../../src/infrastructure/container";
+import { Form } from "../../../src/domain/entities/Form";
+import { Slug } from "../../../src/domain/value-objects/Slug";
+import { sql } from "drizzle-orm";
+
+describe("Security Checks Integration", () => {
+  const userId = "11111111-1111-1111-1111-111111111111";
+  const publicFormId = "rk_frm_live_sec";
+
+  beforeEach(async () => {
+    await clearDatabase();
+    await testDb.execute(sql.raw(`INSERT INTO "users" (id, name, email) VALUES ('${userId}', 'Form Owner', 'sec@example.com') ON CONFLICT DO NOTHING`));
+    
+    const form = new Form({
+      id: "33333333-3333-3333-3333-333333333333",
+      userId,
+      name: "Security Test Form",
+      slug: Slug.create("sec-form"),
+      publicId: publicFormId,
+      config: {}
+    });
+    await container.formRepository.save(form);
+  });
+
+  it("should reject review content exceeding 5000 characters (P0-3)", async () => {
+    const longContent = "a".repeat(5001);
+    const res = await publicRouter.request("/reviews", {
+      method: "POST",
+      body: JSON.stringify({
+        formId: publicFormId,
+        content: longContent,
+        authorName: "Attacker"
+      }),
+      headers: { "Content-Type": "application/json" }
+    });
+
+    expect(res.status).toBe(400);
+    const data = await res.json() as any;
+    expect(data.error).toContain("content is too long");
+  });
+
+  it("should reject authorUrl with unsafe protocols like javascript: (P0-4)", async () => {
+    const unsafeUrls = [
+      "javascript:alert('XSS')",
+      "data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=",
+      "vbscript:msgbox('XSS')",
+      "ftp://example.com"
+    ];
+
+    for (const authorUrl of unsafeUrls) {
+      const res = await publicRouter.request("/reviews", {
+        method: "POST",
+        body: JSON.stringify({
+          formId: publicFormId,
+          content: "Nice!",
+          authorName: "Attacker",
+          authorUrl
+        }),
+        headers: { "Content-Type": "application/json" }
+      });
+
+    if (res.status === 500) {
+      const body = await res.json();
+      console.error('500 Error Body:', body);
+    }
+    expect(res.status).toBe(400);
+      const data = await res.json() as any;
+      // Depending on if it's invalid URL format or fails the protocol check
+      expect(data.error).toBeDefined();
+    }
+  });
+
+  it("should accept valid authorUrl with http or https", async () => {
+    const safeUrls = [
+      "https://google.com",
+      "http://localhost:3000",
+      "https://sub.domain.co.uk/path?query=1"
+    ];
+
+    for (const authorUrl of safeUrls) {
+      const res = await publicRouter.request("/reviews", {
+        method: "POST",
+        body: JSON.stringify({
+          formId: publicFormId,
+          content: "Valid review",
+          authorName: "Good User",
+          authorUrl
+        }),
+        headers: { "Content-Type": "application/json" }
+      });
+
+      expect(res.status).toBe(201);
+    }
+  });
+  
+  it("should rate limit requests to 5 per 15 minutes (P0-5)", async () => {
+    // Send 5 valid requests
+    for (let i = 0; i < 5; i++) {
+        const res = await publicRouter.request("/reviews", {
+            method: "POST",
+            body: JSON.stringify({
+                formId: publicFormId,
+                content: `Review ${i}`,
+                authorName: "Good User"
+            }),
+            headers: { "Content-Type": "application/json" }
+        });
+        expect(res.status).toBe(201);
+    }
+
+    // The 6th request should be rate limited
+    const res = await publicRouter.request("/reviews", {
+        method: "POST",
+        body: JSON.stringify({
+            formId: publicFormId,
+            content: "One too many",
+            authorName: "Spammer"
+        }),
+        headers: { "Content-Type": "application/json" }
+    });
+
+    expect(res.status).toBe(429);
+    const data = await res.json() as any;
+    expect(data.error).toBe("Too many requests, please try again later.");
+  });
+});


### PR DESCRIPTION
### 🚀 Fix database errors in rate limiter and related type issues

**Description**
Cette PR résout l'erreur "Cannot find name 'db'" dans le middleware de rate limiting et stabilise le contrôleur des avis publics. Elle introduit également le support nécessaire au niveau de la base de données pour le rate limiting distribué.

**Changements clés :**
- **Infrastructure** : Création de la table `rate_limits` dans [schema.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/infrastructure/database/schema.ts:0:0-0:0) et mise à jour de [IntegrationSetup.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/tests/integration/IntegrationSetup.ts:0:0-0:0) pour garantir l'isolation des tests.
- **Middleware** : Correction des imports manquants pour `db` et `rateLimits` dans [rateLimiter.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/interface/middlewares/rateLimiter.ts:0:0-0:0).
- **Correction de bugs & Stabilité** : 
    - Fix d'une `TypeError` dans [publicReviewController.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/interface/controllers/publicReviewController.ts:0:0-0:0) lors de la gestion des erreurs de validation Zod.
    - Fix d'une erreur TypeScript dans [auth.ts](cci:7://file:///home/richard/Bureau/REVIEWSKITS/reviews-kits-open/apps/server/src/infrastructure/auth/auth.ts:0:0-0:0) liée à un résultat de requête potentiellement indéfini.
- **Tests** : Ajout d'un cas de test d'intégration vérifiant que le rate limiter rejette bien les requêtes excessives après 5 tentatives (P0-5).

**Vérification :**
- [x] L'analyse statique `tsc --noEmit` est propre (0 erreur).
- [x] Les tests d'intégration de sécurité passent avec succès : `bun test tests/integration/security/SecurityChecks.test.ts`.
