### PR TITLE
fix: copy all workspace package.json in Dockerfiles to fix frozen loc…

### DIFF
--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -4,8 +4,12 @@ WORKDIR /app
 
 # Copier les package.json du workspace
 COPY package.json bun.lock turbo.json ./
+COPY apps/server/package.json ./apps/server/
 COPY apps/admin/package.json ./apps/admin/
+COPY apps/docs/package.json ./apps/docs/
 COPY packages/types/package.json ./packages/types/
+COPY packages/sdk-react/package.json ./packages/sdk-react/
+COPY packages/sdk-vue/package.json ./packages/sdk-vue/
 
 RUN bun install --frozen-lockfile
 

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -5,7 +5,11 @@ WORKDIR /app
 FROM base AS deps
 COPY package.json bun.lock turbo.json ./
 COPY apps/server/package.json ./apps/server/
+COPY apps/admin/package.json ./apps/admin/
+COPY apps/docs/package.json ./apps/docs/
 COPY packages/types/package.json ./packages/types/
+COPY packages/sdk-react/package.json ./packages/sdk-react/
+COPY packages/sdk-vue/package.json ./packages/sdk-vue/
 
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
…kfile error

Bun resolves all workspaces declared in root package.json during install. Only copying a subset of workspace package.json files caused bun to detect a lockfile mismatch and fail with --frozen-lockfile.

## What does this PR do?

<!-- One sentence summary -->

Closes #<!-- issue number -->

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

<!-- List the key changes — files touched, decisions made, tradeoffs -->

- 
- 
- 

---

## How to test

<!-- Steps to verify this works locally -->

1. 
2. 
3. 

---

## Checklist

- [ ] My code follows the project conventions
- [ ] I tested this locally
- [ ] I updated the documentation if needed
- [ ] No console.log or debug code left
- [ ] No `.env` or secrets committed