### PR TITLE
fix(server): remove broken build-types stage from Dockerfile

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -13,13 +13,9 @@ COPY packages/sdk-vue/package.json ./packages/sdk-vue/
 
 RUN bun install --frozen-lockfile
 
-# ─── Build types ─────────────────────────────────────────────
-FROM deps AS build-types
-COPY packages/types ./packages/types
-RUN cd packages/types && bun run build
-
 # ─── Build server ─────────────────────────────────────────────
-FROM build-types AS build-server
+FROM deps AS build-server
+COPY packages/types ./packages/types
 COPY apps/server ./apps/server
 RUN cd apps/server && bun run build
 
@@ -29,9 +25,7 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Uniquement ce qui est nécessaire en prod
 COPY --from=build-server /app/apps/server/dist ./dist
-COPY --from=build-types  /app/packages/types/dist ./packages/types/dist
 COPY --from=deps         /app/node_modules ./node_modules
 
 EXPOSE 3000


### PR DESCRIPTION
packages/types tsconfig has noEmit:true so tsc never produces a dist/. The server bundle (bun build) already inlines all 991 modules including @reviewskits/types, so copying types/dist at runtime was unnecessary.

## What does this PR do?

<!-- One sentence summary -->

Closes #<!-- issue number -->

---

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

<!-- List the key changes — files touched, decisions made, tradeoffs -->

- 
- 
- 

---

## How to test

<!-- Steps to verify this works locally -->

1. 
2. 
3. 

---

## Checklist

- [ ] My code follows the project conventions
- [ ] I tested this locally
- [ ] I updated the documentation if needed
- [ ] No console.log or debug code left
- [ ] No `.env` or secrets committed