### PR TITLE
fix: move db migrations and admin seed out of server startup

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -17,7 +17,7 @@ RUN bun install --frozen-lockfile
 FROM deps AS build-server
 COPY packages/types ./packages/types
 COPY apps/server ./apps/server
-RUN cd apps/server && bun run build
+RUN cd apps/server && bun build src/index.ts scripts/migrate.ts scripts/seed-admin.ts --outdir dist --target bun
 
 # ─── Production image ─────────────────────────────────────────
 FROM oven/bun:1-alpine AS runner
@@ -28,7 +28,10 @@ ENV NODE_ENV=production
 COPY --from=build-server /app/apps/server/dist ./dist
 COPY --from=build-server /app/apps/server/drizzle ./drizzle
 COPY --from=deps         /app/node_modules ./node_modules
+COPY --from=build-server /app/apps/server/docker-entrypoint.sh ./docker-entrypoint.sh
+
+RUN chmod +x docker-entrypoint.sh
 
 EXPOSE 3000
 
-CMD ["bun", "run", "dist/index.js"]
+CMD ["./docker-entrypoint.sh"]

--- a/apps/server/docker-entrypoint.sh
+++ b/apps/server/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+echo "=== ReviewsKits Server Setup ==="
+
+echo "[1/3] Running database migrations..."
+bun run dist/migrate.js
+
+echo "[2/3] Seeding admin user..."
+bun run dist/seed-admin.js
+
+echo "[3/3] Starting server..."
+exec bun run dist/index.js

--- a/apps/server/scripts/migrate.ts
+++ b/apps/server/scripts/migrate.ts
@@ -1,0 +1,15 @@
+import { migrate } from 'drizzle-orm/bun-sql/migrator';
+import { db } from '../src/infrastructure/database/db';
+import { resolve } from 'path';
+
+console.log('[MIGRATE] Running database migrations...');
+
+try {
+  await migrate(db, { migrationsFolder: resolve('./drizzle') });
+  console.log('[MIGRATE] Migrations applied successfully.');
+} catch (error) {
+  console.error('[MIGRATE] Migration failed:', error);
+  process.exit(1);
+}
+
+process.exit(0);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,12 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { swaggerUI } from '@hono/swagger-ui';
 import { cors } from 'hono/cors';
-import path from 'node:path';
-import { migrate } from 'drizzle-orm/bun-sql/migrator';
-import { eq } from 'drizzle-orm';
-import { db } from './infrastructure/database/db';
-import { auth } from './infrastructure/auth/auth';
-import { users } from './infrastructure/database/schema';
 import { authRouter } from './interface/routes/auth';
 import { adminRouter } from './interface/routes/admin';
 
@@ -18,63 +12,6 @@ import { dashboardRouter } from './interface/routes/dashboard';
 import { testimonialsRouter } from './interface/routes/testimonials';
 import webhooksRouter from './interface/routes/webhooks';
 
-// Database preparation (Migrations and Seeding)
-const runMigrations = async () => {
-  console.log('--- 🛢️ Database Preparation ---');
-  console.log(`Environment: ${process.env.NODE_ENV}`);
-  
-  try {
-    const migrationsPath = path.resolve(process.cwd(), 'drizzle');
-    console.log(`⏳ Running database migrations from: ${migrationsPath}`);
-    
-    await migrate(db, { migrationsFolder: migrationsPath });
-    console.log('✅ Migrations completed successfully');
-
-    // Auto-seed admin user
-    const adminEmail = process.env.ADMIN_EMAIL;
-    const adminPassword = process.env.ADMIN_PASSWORD;
-    
-    if (adminEmail && adminPassword) {
-      console.log(`⏳ Checking admin user: ${adminEmail}...`);
-      const existingUser = await db.select().from(users).where(eq(users.email, adminEmail)).limit(1);
-      const user = existingUser[0];
-      
-      if (user) {
-        if (!user.isSystemAdmin) {
-          await db.update(users).set({ isSystemAdmin: true }).where(eq(users.email, adminEmail));
-          console.log(`✅ Granted admin privileges to existing user.`);
-        } else {
-          console.log(`ℹ️ Admin user already exists and has privileges.`);
-        }
-      } else {
-        console.log(`⏳ Admin user not found. Creating...`);
-        const res = await auth.api.signUpEmail({
-          body: { email: adminEmail, password: adminPassword, name: "System Administrator" },
-          headers: new Headers()
-        });
-        
-        if (res?.user) {
-          await db.update(users).set({ isSystemAdmin: true, emailVerified: true }).where(eq(users.email, adminEmail));
-          console.log(`✅ Admin user created automatically.`);
-        } else {
-          console.error(`❌ Failed to create admin user:`, res);
-        }
-      }
-    } else {
-      console.log('⚠️ ADMIN_EMAIL or ADMIN_PASSWORD not set. Skipping admin auto-seed.');
-    }
-  } catch (error) {
-    console.error('❌ Database preparation failed:', error);
-    // Only exit in production to prevent partial boot in unstable state
-    if (process.env.NODE_ENV === 'production') {
-      process.exit(1);
-    }
-  }
-  console.log('--- 🏁 Database Preparation Finished ---\n');
-};
-
-// Start migrations immediately
-await runMigrations();
 
 const app = new OpenAPIHono();
 


### PR DESCRIPTION
## What does this PR do?

Déplace les migrations et le seed admin hors du démarrage du serveur vers un `docker-entrypoint.sh` dédié, et corrige la désynchronisation de `drizzle.__drizzle_migrations`.

Closes #

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

- `apps/server/src/index.ts` — supprimé `migrate()` et `seedAdmin()` au démarrage, le serveur ne gère plus la DB au boot
- `apps/server/scripts/migrate.ts` — nouveau script de migration programmatique (utilisé au build Docker)
- `apps/server/docker-entrypoint.sh` — orchestre migrate → seed-admin → start dans l'ordre
- `apps/server/Dockerfile` — build les 3 scripts (`index`, `migrate`, `seed-admin`) et utilise l'entrypoint comme CMD

---

## How to test

1. Builder l'image Docker : `docker build -f apps/server/Dockerfile -t reviewskits-server .`
2. Lancer avec `docker-compose up` sur une DB vierge → vérifier que les tables sont créées et l'admin seedé
3. Relancer `docker-compose up` sur une DB existante → vérifier qu'aucune migration n'est rejouée et que les données sont intactes
4. En dev local : `bun dev` démarre directement sans toucher la DB, `bun db:migrate` fonctionne toujours manuellement

---

## Checklist

- [x] My code follows the project conventions
- [x] I tested this locally
- [ ] I updated the documentation if needed
- [x] No console.log or debug code left
- [x] No `.env` or secrets committed