### PR TITLE
fix(admin): replace overlay with document click listener to close pro…

### DIFF
--- a/apps/admin/src/components/dashboard/profile-menu.tsx
+++ b/apps/admin/src/components/dashboard/profile-menu.tsx
@@ -73,9 +73,7 @@ export const ProfileMenu = ({ isOpen, onClose }: ProfileMenuProps) => {
   if (!isOpen) return null
 
   return (
-    <>
-      <div className="fixed inset-0 z-[250]" onClick={(e) => { e.stopPropagation(); onClose(); }} />
-      <div className="absolute top-full right-0 mt-2 w-80 bg-[var(--v3-bg2)] border border-[var(--v3-border)] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.15),0_32px_80px_rgba(0,0,0,0.25)] overflow-hidden z-[300] animate-in fade-in zoom-in-95 duration-200 origin-top-right">
+    <div className="absolute top-full right-0 mt-2 w-80 bg-[var(--v3-bg2)] border border-[var(--v3-border)] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.15),0_32px_80px_rgba(0,0,0,0.25)] overflow-hidden z-[300] animate-in fade-in zoom-in-95 duration-200 origin-top-right" onClick={(e) => e.stopPropagation()}>
         {/* Header */}
         <div className="p-5 border-b border-[var(--v3-border)] bg-[var(--v3-bg3)]/40">
            <div className="flex items-center gap-3 mb-1">
@@ -207,6 +205,5 @@ export const ProfileMenu = ({ isOpen, onClose }: ProfileMenuProps) => {
            </a>
         </div>
       </div>
-    </>
   )
 }

--- a/apps/admin/src/components/dashboard/top-bar.tsx
+++ b/apps/admin/src/components/dashboard/top-bar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Bell, ChevronDown } from 'lucide-react'
 import { ProfileMenu } from './profile-menu'
 import { authClient } from '../../lib/auth-client'
@@ -7,6 +7,13 @@ import logo from '../../assets/logo.svg'
 export const TopBar = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const { data: session } = authClient.useSession()
+
+  useEffect(() => {
+    if (!isMenuOpen) return
+    const close = () => setIsMenuOpen(false)
+    document.addEventListener('click', close)
+    return () => document.removeEventListener('click', close)
+  }, [isMenuOpen])
 
   return (
     <header className="sticky top-0 z-[200] h-16 flex items-center border-b border-[var(--v3-border)] bg-[var(--v3-bg)]/90 backdrop-blur-xl">
@@ -24,8 +31,8 @@ export const TopBar = () => {
           </button>
           
           <div className="relative">
-            <div 
-              onClick={() => setIsMenuOpen(!isMenuOpen)}
+            <div
+              onClick={(e) => { e.stopPropagation(); setIsMenuOpen(prev => !prev) }}
               className="flex items-center gap-2.5 bg-[var(--v3-bg2)] border border-[var(--v3-border)] rounded-full py-1.5 pl-1.5 pr-3.5 cursor-pointer hover:border-[var(--v3-border2)] transition-all group"
             >
               <div className="w-7.5 h-7.5 rounded-full bg-gradient-to-br from-[var(--v3-teal)] to-[#0a6e52] flex items-center justify-center text-[11px] font-bold text-white shadow-[0_0_15px_rgba(45,212,191,0.2)]">


### PR DESCRIPTION
fix(admin): close profile menu on outside click

## What does this PR do?

Replaces the overlay-based dismiss pattern in the profile menu with a document-level click listener so clicking anywhere outside the menu correctly closes it.

Closes #<!-- issue number -->

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

- `top-bar.tsx` — added a `useEffect` that attaches a `click` listener on `document` when the menu is open, and removes it on close or unmount
- `top-bar.tsx` — added `e.stopPropagation()` on the trigger button so opening the menu doesn't immediately trigger the document listener
- `profile-menu.tsx` — removed the `fixed inset-0 z-[250]` overlay div; it was rendered inside a `backdrop-blur-xl` header which creates a CSS stacking context and prevented the overlay from covering the full viewport
- `profile-menu.tsx` — added `e.stopPropagation()` on the menu panel so clicks inside the menu don't bubble up to the document listener

---

## How to test

1. Start the admin app locally (`bun run dev` from `apps/admin`)
2. Click your avatar/name in the top-right to open the profile menu
3. Click anywhere outside the menu — it should close immediately
4. Re-open the menu, click a link or button inside it — the menu should behave normally

---

## Checklist

- [x] My code follows the project conventions
- [x] I tested this locally
- [ ] I updated the documentation if needed
- [x] No console.log or debug code left
- [x] No `.env` or secrets committed
