### PR TITLE
fix(dx): fix DATABASE_URL for local dev and add make dev command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,11 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=your_secure_password
 POSTGRES_DB=reviewskits
 
-# URL interne Docker (ne pas modifier le host "db")
-DATABASE_URL=postgresql://postgres:your_secure_password@db:5432/reviewskits
+# Local dev URL — bun dev runs on the host, use localhost with the mapped port
+DATABASE_URL=postgresql://postgres:your_secure_password@localhost:5433/reviewskits
+
+# Production / Docker-internal URL (only use this inside the Docker network)
+# DATABASE_URL=postgresql://postgres:your_secure_password@db:5432/reviewskits
 
 # ─── Auth ──────────────────────────────────────────────────────
 BETTER_AUTH_SECRET=your_super_secret_auth_key_min_32_chars

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Thanks for taking the time to contribute. This guide will get you up and running
 - [Bun](https://bun.sh) >= 1.0
 - [Docker](https://docker.com) >= 24.0
 - [Git](https://git-scm.com)
+- [Make](https://www.gnu.org/software/make/) (pre-installed on macOS and Linux)
 
 ```bash
 # 1. Fork the repo, then clone your fork
@@ -27,18 +28,32 @@ cd reviews-kits
 # 2. Install dependencies
 bun install
 
-# 3. Start the local infrastructure (DB, Redis, Minio)
-# This file only contains the necessary services for local development, excluding the app itself.
-docker compose -f infra/docker-compose.dev.yml up -d
-
-# 4. Copy environment variables
+# 3. Copy environment variables
 cp .env.example .env
 
-# 5. Push the database schema
-# The API uses Drizzle ORM. You must push the schema to the empty local DB before running the app.
-cd apps/server && bunx drizzle-kit push && cd ../..
+# 4. Start everything with a single command
+make dev
+```
 
-# 6. Start the dev server
+`make dev` handles the full setup automatically: starts the Docker infrastructure (PostgreSQL, Redis, MinIO, Mailpit), waits for the database to be ready, pushes the schema, and starts the dev server in hot-reload mode.
+
+To stop the infrastructure:
+```bash
+make stop
+```
+
+### Windows (without Make)
+
+If you are on Windows and don't have `make`, run these steps manually:
+
+```bash
+# Start infrastructure
+docker compose -f infra/docker-compose.dev.yml up -d
+
+# Wait for the DB to be ready, then push the schema
+cd apps/server && bun run db:push && cd ../..
+
+# Start the dev server
 bun run dev
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: dev stop
+
+dev:
+	@echo "Starting infrastructure..."
+	docker compose -f infra/docker-compose.dev.yml up -d
+	@echo "Waiting for database to be ready..."
+	@until docker compose -f infra/docker-compose.dev.yml exec db pg_isready -U postgres > /dev/null 2>&1; do sleep 1; done
+	@echo "Pushing database schema..."
+	cd apps/server && bun run db:push
+	@echo "Starting dev server..."
+	bun run dev
+
+stop:
+	docker compose -f infra/docker-compose.dev.yml down


### PR DESCRIPTION
## Fix: broken dev experience — DATABASE_URL unreachable from host + missing schema setup

Closes #103 

## Changes

### `.env.example`
- Changed `DATABASE_URL` to point to `localhost:5433` instead of `db:5432`
- `db` is a Docker-internal hostname — it only resolves inside the Docker network, not from the host where `bun dev` runs
- The production/Docker-internal URL is kept as a comment for reference

### `Makefile` (new file)
- Added a `make dev` command that orchestrates the full dev startup in the correct order:
  1. Starts Docker infrastructure (PostgreSQL, Redis, MinIO, Mailpit)
  2. Waits for the database to be healthy (`pg_isready`)
  3. Pushes the schema via `drizzle-kit push` (idempotent — safe to re-run)
  4. Starts the dev server in hot-reload mode
- Added a `make stop` command to tear down the infrastructure

### `CONTRIBUTING.md`
- Replaced the 6-step manual setup with a single `make dev` command
- Added a **Windows (without Make)** fallback section with the equivalent manual steps

## Why `drizzle-kit push` and not `scripts/migrate.ts`

The existing `CONTRIBUTING.md` already documented `drizzle-kit push` as the dev approach.
This is intentional — `push` applies the schema directly without requiring migration files,
which is simpler for local dev. Production continues to use `scripts/migrate.ts` via
`docker-entrypoint.sh`, which is unchanged.

## How to test

```bash
# Fresh clone simulation
cp .env.example .env
make dev
# Expected: infra starts, schema is pushed, server starts without errors
```

Re-running `make dev` after pulling new schema changes should also work without any manual steps.
