### PR TITLE
Fix/docker compose no proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,11 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=your_secure_password
 POSTGRES_DB=reviewskits
 
-# URL interne Docker (ne pas modifier le host "db")
-DATABASE_URL=postgresql://postgres:your_secure_password@db:5432/reviewskits
+# Local dev URL — bun dev runs on the host, use localhost with the mapped port
+DATABASE_URL=postgresql://postgres:your_secure_password@localhost:5433/reviewskits
+
+# Production / Docker-internal URL (only use this inside the Docker network)
+# DATABASE_URL=postgresql://postgres:your_secure_password@db:5432/reviewskits
 
 # ─── Auth ──────────────────────────────────────────────────────
 BETTER_AUTH_SECRET=your_super_secret_auth_key_min_32_chars

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ Thanks for taking the time to contribute. This guide will get you up and running
 - [Bun](https://bun.sh) >= 1.0
 - [Docker](https://docker.com) >= 24.0
 - [Git](https://git-scm.com)
+- [Make](https://www.gnu.org/software/make/) (pre-installed on macOS and Linux)
 
 ```bash
 # 1. Fork the repo, then clone your fork
@@ -27,18 +28,32 @@ cd reviews-kits
 # 2. Install dependencies
 bun install
 
-# 3. Start the local infrastructure (DB, Redis, Minio)
-# This file only contains the necessary services for local development, excluding the app itself.
-docker compose -f infra/docker-compose.dev.yml up -d
-
-# 4. Copy environment variables
+# 3. Copy environment variables
 cp .env.example .env
 
-# 5. Push the database schema
-# The API uses Drizzle ORM. You must push the schema to the empty local DB before running the app.
-cd apps/server && bunx drizzle-kit push && cd ../..
+# 4. Start everything with a single command
+make dev
+```
 
-# 6. Start the dev server
+`make dev` handles the full setup automatically: starts the Docker infrastructure (PostgreSQL, Redis, MinIO, Mailpit), waits for the database to be ready, pushes the schema, and starts the dev server in hot-reload mode.
+
+To stop the infrastructure:
+```bash
+make stop
+```
+
+### Windows (without Make)
+
+If you are on Windows and don't have `make`, run these steps manually:
+
+```bash
+# Start infrastructure
+docker compose -f infra/docker-compose.dev.yml up -d
+
+# Wait for the DB to be ready, then push the schema
+cd apps/server && bun run db:push && cd ../..
+
+# Start the dev server
 bun run dev
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: dev stop
+
+dev:
+	@echo "Starting infrastructure..."
+	docker compose -f infra/docker-compose.dev.yml up -d
+	@echo "Waiting for database to be ready..."
+	@until docker compose -f infra/docker-compose.dev.yml exec db pg_isready -U postgres > /dev/null 2>&1; do sleep 1; done
+	@echo "Pushing database schema..."
+	cd apps/server && bun run db:push
+	@echo "Starting dev server..."
+	bun run dev
+
+stop:
+	docker compose -f infra/docker-compose.dev.yml down

--- a/apps/docs/docs/guide/deployment.md
+++ b/apps/docs/docs/guide/deployment.md
@@ -4,22 +4,30 @@ Reviewskits is fully containerized and designed to be self-hosted on any VPS or 
 
 ---
 
-## 🏗️ Production Setup
+## Choosing the right compose file
 
-Before deploying, ensure you have a domain pointed to your server's IP address (A Record). Reviewskits uses Traefik by default to handle SSL certificates via Let's Encrypt.
+| File | When to use |
+|------|-------------|
+| `docker-compose.yml` | VPS with ports 80/443 free — Traefik handles SSL automatically |
+| `docker-compose.coolify.yml` | Deploying via [Coolify](https://coolify.io/) — SSL managed by Coolify |
+| `docker-compose.no-proxy.yml` | Existing reverse proxy (Nginx, Caddy, HAProxy…) — ports 80/443 already taken |
 
-### Environment Variables
-You will need to configure the following variables in your `.env` file or PaaS dashboard:
+---
+
+## 🏗️ Common environment variables
+
+All deployment options share these variables:
 
 | Variable | Description |
 |---|---|
 | `DOMAIN` | Your deployment domain (e.g., `reviews.example.com`) |
-| `ACME_EMAIL` | Email for SSL certificate notifications |
 | `DATABASE_URL` | `postgresql://postgres:PASSWORD@db:5432/reviewskits` |
 | `POSTGRES_PASSWORD` | A secure password for the database |
 | `BETTER_AUTH_SECRET` | A random 32-character string |
 | `ADMIN_EMAIL` | The email you'll use to log in |
 | `ADMIN_PASSWORD` | Your admin password |
+
+> `ACME_EMAIL` is only required for **Option A** (Traefik). It is not needed for Coolify or no-proxy setups.
 
 ---
 
@@ -208,8 +216,54 @@ volumes:
 
 ---
 
+## 🔧 Option C: Existing Reverse Proxy (Nginx, Caddy, HAProxy…)
+
+Use this if ports 80 and 443 are already handled by your own proxy. The services are exposed directly on the host — point your proxy at `localhost:8080` (admin) and `localhost:3000` (API).
+
+**1. Create a `.env` file** (no `ACME_EMAIL` needed):
+```env
+# --- Domain ---
+DOMAIN=yourdomain.com
+
+# --- Database ---
+POSTGRES_PASSWORD=generate_a_secure_password
+DATABASE_URL=postgresql://postgres:generate_a_secure_password@db:5432/reviewskits
+
+# --- Auth & Admin ---
+BETTER_AUTH_SECRET=generate_a_random_32_chars_string
+ADMIN_EMAIL=your@email.com
+ADMIN_PASSWORD=your_secure_admin_password
+```
+
+**2. Launch**:
+```bash
+docker compose -f infra/docker-compose.no-proxy.yml up -d
+```
+
+**3. Configure your proxy** to forward traffic:
+- `yourdomain.com` → `localhost:8080` (admin frontend)
+- `yourdomain.com/api` → `localhost:3000` (API)
+
+Example Nginx config:
+```nginx
+server {
+    listen 443 ssl;
+    server_name yourdomain.com;
+
+    location /api {
+        proxy_pass http://localhost:3000;
+    }
+
+    location / {
+        proxy_pass http://localhost:8080;
+    }
+}
+```
+
+---
+
 ## 🔐 Security Best Practices
 
 1. **Better Auth Secret**: Generate a strong 32-character random string.
 2. **Database Backups**: If using the Docker database, ensure the `db-data` volume is backed up.
-3. **HTTPS**: Traefik handles this automatically in Option A. In Option B, Coolify takes care of it.
+3. **HTTPS**: Traefik handles this automatically in Option A. In Option B, Coolify takes care of it. In Option C, your existing proxy is responsible for SSL.

--- a/apps/docs/docs/guide/env.md
+++ b/apps/docs/docs/guide/env.md
@@ -58,9 +58,8 @@ See the [Email Notifications guide](/guide/email) for production configuration a
 Use these secure configurations when deploying to your `.env` in production:
 
 ```env
-# --- Domain & SSL ---
+# --- Domain ---
 DOMAIN=your.domain.tld
-ACME_EMAIL=example@gmail.com
 NODE_ENV=production
 
 # --- Database ---
@@ -72,3 +71,7 @@ BETTER_AUTH_SECRET=generate_a_random_32_chars_string
 ADMIN_EMAIL=your@email.com
 ADMIN_PASSWORD=your_secure_admin_password
 ```
+
+> **`ACME_EMAIL`** is only required when using `docker-compose.yml` (Traefik with Let's Encrypt automatic SSL).
+> It is **not needed** for Coolify (`docker-compose.coolify.yml`) or existing proxy setups (`docker-compose.no-proxy.yml`).
+> See the [Deployment guide](/guide/deployment) to choose the right option for your setup.

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,3 +1,10 @@
+# ┌─────────────────────────────────────────────────────────────────┐
+# │  Développement local — infrastructure uniquement                │
+# │  Lance : PostgreSQL, Redis, MinIO, Mailpit                      │
+# │  L'application (bun dev) tourne sur le host, pas dans Docker   │
+# │  Usage  : make dev  (ou docker compose -f infra/docker-compose.dev.yml up -d) │
+# └─────────────────────────────────────────────────────────────────┘
+
 services:
   db:
     image: postgres:16-alpine

--- a/infra/docker-compose.no-proxy.yml
+++ b/infra/docker-compose.no-proxy.yml
@@ -1,7 +1,9 @@
 # ┌─────────────────────────────────────────────────────────────────┐
-# │  PaaS Coolify — SSL et réseau gérés par Coolify                 │
-# │  Requis : instance Coolify configurée                           │
-# │  Usage  : coller ce fichier dans un Docker Compose Resource     │
+# │  Proxy existant — Nginx, Caddy, HAProxy, Apache, etc.           │
+# │  Ports 80/443 déjà pris ? Utilisez ce fichier.                  │
+# │  Expose admin sur :8080 et API sur :3000 — pointez votre proxy  │
+# │  vers ces ports. SSL géré par votre proxy existant.             │
+# │  Usage  : docker compose -f infra/docker-compose.no-proxy.yml up -d │
 # └─────────────────────────────────────────────────────────────────┘
 
 services:
@@ -9,7 +11,8 @@ services:
   admin:
     image: ghcr.io/reviews-kits-team/reviewskits-admin:latest
     restart: unless-stopped
-    # Coolify will handle the domain and SSL for this service
+    ports:
+      - "8080:80"
     networks:
       - reviewskits
 
@@ -17,6 +20,8 @@ services:
   server:
     image: ghcr.io/reviews-kits-team/reviewskits-server:latest
     restart: unless-stopped
+    ports:
+      - "3000:3000"
     environment:
       NODE_ENV: production
       DATABASE_URL: ${DATABASE_URL}
@@ -34,7 +39,7 @@ services:
     networks:
       - reviewskits
 
-  # ─── Database ──────────────────────────────────────────
+  # ─── Database ──────────────────────────────────────────────────
   db:
     image: postgres:16-alpine
     restart: unless-stopped

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,3 +1,9 @@
+# ┌─────────────────────────────────────────────────────────────────┐
+# │  VPS standard — Traefik intégré, SSL automatique Let's Encrypt  │
+# │  Requis : un domaine pointé sur le serveur + ports 80/443 libres │
+# │  Usage  : docker compose -f infra/docker-compose.yml up -d      │
+# └─────────────────────────────────────────────────────────────────┘
+
 services:
   # ─── Reverse Proxy ────────────────────────────────────────────
   traefik:


### PR DESCRIPTION
## Fix: add docker-compose for users with an existing reverse proxy

Closes #95

## Changes

### `infra/docker-compose.no-proxy.yml` (new file)
- New compose variant for users whose ports 80/443 are already handled by an existing proxy (Nginx, Caddy, HAProxy, etc.)
- Exposes services directly on the host: admin → `:8080`, API → `:3000`
- No Traefik, no ACME challenge, no `letsencrypt` volume
- Based on `docker-compose.coolify.yml` as a starting point

### Header comments on all compose files
- Each compose file now has a clear header explaining when to use it, what it requires, and the exact command to run
- Removes any ambiguity about which file to pick for a given setup

### `apps/docs/docs/guide/deployment.md`
- Added a selection table at the top of the page to help users pick the right compose file at a glance
- Grouped common environment variables in one place
- Added a note clarifying that `ACME_EMAIL` is only required for Option A (Traefik)
- Added Option C (existing proxy) with a minimal `.env`, the launch command, and an Nginx config example

### `apps/docs/docs/guide/env.md`
- Removed `ACME_EMAIL` from the default production config block
- Added a note explaining it is only needed with `docker-compose.yml` (Traefik) with a link to the deployment guide

## The three deployment options are now

| File | When to use |
|------|-------------|
| `docker-compose.yml` | VPS with ports 80/443 free — Traefik handles SSL |
| `docker-compose.coolify.yml` | Deploying via Coolify |
| `docker-compose.no-proxy.yml` | Existing reverse proxy (Nginx, Caddy, HAProxy…) |
