### PR TITLE
feat: compact public form rendering for tighter, Typeform-like layout

### DIFF
--- a/apps/admin/src/pages/PublicFormPage.tsx
+++ b/apps/admin/src/pages/PublicFormPage.tsx
@@ -1,167 +1,189 @@
-import { useState, useEffect } from 'react'
-import { useParams } from 'react-router-dom'
-import { Loader2 } from 'lucide-react'
-import confetti from 'canvas-confetti'
-import type { FormData, FormStep, StepField } from './public-form/types'
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { Loader2 } from "lucide-react";
+import confetti from "canvas-confetti";
+import type { FormData, FormStep, StepField } from "./public-form/types";
 
 // Step Components
-import { WelcomeStep } from './public-form/steps/WelcomeStep'
-import { InformativeStep } from './public-form/steps/InformativeStep'
-import { RatingStep } from './public-form/steps/RatingStep'
-import { TextareaStep } from './public-form/steps/TextareaStep'
-import { AttributionStep } from './public-form/steps/AttributionStep'
-import { IdentityStep } from './public-form/steps/IdentityStep'
-import { CoreStep } from './public-form/steps/CoreStep'
-import { CustomStep } from './public-form/steps/CustomStep'
-import { SuccessStep } from './public-form/steps/SuccessStep'
+import { WelcomeStep } from "./public-form/steps/WelcomeStep";
+import { InformativeStep } from "./public-form/steps/InformativeStep";
+import { RatingStep } from "./public-form/steps/RatingStep";
+import { TextareaStep } from "./public-form/steps/TextareaStep";
+import { AttributionStep } from "./public-form/steps/AttributionStep";
+import { IdentityStep } from "./public-form/steps/IdentityStep";
+import { CoreStep } from "./public-form/steps/CoreStep";
+import { CustomStep } from "./public-form/steps/CustomStep";
+import { SuccessStep } from "./public-form/steps/SuccessStep";
 
 export default function PublicFormPage() {
-  const { slug } = useParams()
-  const [form, setForm] = useState<FormData | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [currentStepIndex, setCurrentStepIndex] = useState(0)
-  
+  const { slug } = useParams();
+  const [form, setForm] = useState<FormData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+
   // Response state
-  const [rating, setRating] = useState<number>(0)
-  const [content, setContent] = useState('')
-  const [authorName, setAuthorName] = useState('')
-  const [authorEmail, setAuthorEmail] = useState('')
-  const [authorTitle, setAuthorTitle] = useState('')
-  const [authorUrl, setAuthorUrl] = useState('')
-  const [submitting, setSubmitting] = useState(false)
+  const [rating, setRating] = useState<number>(0);
+  const [content, setContent] = useState("");
+  const [authorName, setAuthorName] = useState("");
+  const [authorEmail, setAuthorEmail] = useState("");
+  const [authorTitle, setAuthorTitle] = useState("");
+  const [authorUrl, setAuthorUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
   // Selection state for custom step fields (fieldId → selected value)
-  const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({})
+  const [customFieldValues, setCustomFieldValues] = useState<
+    Record<string, unknown>
+  >({});
 
   useEffect(() => {
     const fetchForm = async () => {
       try {
-        const res = await fetch(`/api/v1/public/forms/${slug}`)
+        const res = await fetch(`/api/v1/public/forms/${slug}`);
         if (!res.ok) {
-          const data = await res.json()
-          throw new Error(data.error || 'Form not found')
+          const data = await res.json();
+          throw new Error(data.error || "Form not found");
         }
-        const data = await res.json()
+        const data = await res.json();
         // Filter enabled steps
-        data.config.steps = data.config.steps.filter((s: FormStep) => s.isEnabled)
-        setForm(data)
+        data.config.steps = data.config.steps.filter(
+          (s: FormStep) => s.isEnabled,
+        );
+        setForm(data);
       } catch (err: unknown) {
-        setError(err instanceof Error ? err.message : 'An error occurred');
+        setError(err instanceof Error ? err.message : "An error occurred");
       } finally {
-        setLoading(false)
+        setLoading(false);
       }
-    }
-    fetchForm()
-  }, [slug])
+    };
+    fetchForm();
+  }, [slug]);
 
-  const steps = form?.config?.steps || []
-  const currentStep = steps[currentStepIndex]
-  const branding = form?.config?.branding
-  const primaryColor = branding?.primaryColor || '#0D9E75'
+  const steps = form?.config?.steps || [];
+  const currentStep = steps[currentStepIndex];
+  const branding = form?.config?.branding;
+  const primaryColor = branding?.primaryColor || "#0D9E75";
 
   // Trigger confetti on success
   useEffect(() => {
-    if (currentStep?.type === 'success') {
-      const duration = 3 * 1000
-      const animationEnd = Date.now() + duration
-      const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 }
+    if (currentStep?.type === "success") {
+      const duration = 3 * 1000;
+      const animationEnd = Date.now() + duration;
+      const defaults = { startVelocity: 30, spread: 360, ticks: 60, zIndex: 0 };
 
-      const randomInRange = (min: number, max: number) => Math.random() * (max - min) + min
+      const randomInRange = (min: number, max: number) =>
+        Math.random() * (max - min) + min;
 
-      const interval = setInterval(function() {
-        const timeLeft = animationEnd - Date.now()
+      const interval = setInterval(function () {
+        const timeLeft = animationEnd - Date.now();
 
         if (timeLeft <= 0) {
-          return clearInterval(interval)
+          return clearInterval(interval);
         }
 
-        const particleCount = 50 * (timeLeft / duration)
-        confetti({ ...defaults, particleCount, origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 }, colors: [primaryColor, '#ffffff'] })
-        confetti({ ...defaults, particleCount, origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 }, colors: [primaryColor, '#ffffff'] })
-      }, 250)
+        const particleCount = 50 * (timeLeft / duration);
+        confetti({
+          ...defaults,
+          particleCount,
+          origin: { x: randomInRange(0.1, 0.3), y: Math.random() - 0.2 },
+          colors: [primaryColor, "#ffffff"],
+        });
+        confetti({
+          ...defaults,
+          particleCount,
+          origin: { x: randomInRange(0.7, 0.9), y: Math.random() - 0.2 },
+          colors: [primaryColor, "#ffffff"],
+        });
+      }, 250);
 
-      return () => clearInterval(interval)
+      return () => clearInterval(interval);
     }
-  }, [currentStep?.type, primaryColor])
+  }, [currentStep?.type, primaryColor]);
 
-  const headingFont = branding?.headingFont || 'Inter'
-  const bodyFont = branding?.bodyFont || 'Inter'
-  const [fontsReady, setFontsReady] = useState(false)
+  const headingFont = branding?.headingFont || "Inter";
+  const bodyFont = branding?.bodyFont || "Inter";
+  const [fontsReady, setFontsReady] = useState(false);
 
-  const getFontUrl = (font: string) => `https://fonts.googleapis.com/css2?family=${font.replace(/ /g, '+')}:wght@400;700;900&display=swap`
+  const getFontUrl = (font: string) =>
+    `https://fonts.googleapis.com/css2?family=${font.replace(/ /g, "+")}:wght@400;700;900&display=swap`;
 
   // Load fonts and apply only once ready to prevent FOUT
   useEffect(() => {
-    let cancelled = false
-    const fonts = [headingFont, bodyFont]
-    const links: HTMLLinkElement[] = []
+    let cancelled = false;
+    const fonts = [headingFont, bodyFont];
+    const links: HTMLLinkElement[] = [];
 
-    fonts.forEach(font => {
-      const id = `font-${font.replace(/ /g, '-')}`
+    fonts.forEach((font) => {
+      const id = `font-${font.replace(/ /g, "-")}`;
       if (!document.getElementById(id)) {
-        const link = document.createElement('link')
-        link.id = id
-        link.rel = 'stylesheet'
-        link.href = getFontUrl(font)
-        document.head.appendChild(link)
-        links.push(link)
+        const link = document.createElement("link");
+        link.id = id;
+        link.rel = "stylesheet";
+        link.href = getFontUrl(font);
+        document.head.appendChild(link);
+        links.push(link);
       }
-    })
+    });
 
-    Promise.all(fonts.map(f => document.fonts.load(`700 1em "${f}"`))).then(() => {
-      if (!cancelled) setFontsReady(true)
-    })
+    Promise.all(fonts.map((f) => document.fonts.load(`700 1em "${f}"`))).then(
+      () => {
+        if (!cancelled) setFontsReady(true);
+      },
+    );
 
     return () => {
-      cancelled = true
-      links.forEach(link => {
-        if (link.parentNode) document.head.removeChild(link)
-      })
-      setFontsReady(false)
-    }
-  }, [headingFont, bodyFont])
+      cancelled = true;
+      links.forEach((link) => {
+        if (link.parentNode) document.head.removeChild(link);
+      });
+      setFontsReady(false);
+    };
+  }, [headingFont, bodyFont]);
 
-  const appliedHeadingFont = fontsReady ? headingFont : 'system-ui, sans-serif'
-  const appliedBodyFont = fontsReady ? bodyFont : 'system-ui, sans-serif'
+  const appliedHeadingFont = fontsReady ? headingFont : "system-ui, sans-serif";
+  const appliedBodyFont = fontsReady ? bodyFont : "system-ui, sans-serif";
 
   const handleNext = async () => {
-    if (currentStep?.type === 'identity' || currentStep?.type === 'attribution') {
-      await handleSubmit()
+    if (
+      currentStep?.type === "identity" ||
+      currentStep?.type === "attribution"
+    ) {
+      await handleSubmit();
     } else {
-      setCurrentStepIndex(prev => prev + 1)
+      setCurrentStepIndex((prev) => prev + 1);
     }
-  }
+  };
 
   const handleSubmit = async () => {
-    if (!form) return
-    setSubmitting(true)
+    if (!form) return;
+    setSubmitting(true);
     try {
       // Build metadata from custom step field answers
-      const metadata: Record<string, unknown> = {}
-      steps.forEach(step => {
-        if (step.type === 'custom') {
-          const fields = ((step.config as Record<string, unknown>)?.fields || []) as StepField[]
-          fields.forEach(field => {
-            const val = customFieldValues[field.id]
-            if (val === undefined) return
-            if (field.type === 'grid') {
+      const metadata: Record<string, unknown> = {};
+      steps.forEach((step) => {
+        if (step.type === "custom") {
+          const fields = ((step.config as Record<string, unknown>)?.fields ||
+            []) as StepField[];
+          fields.forEach((field) => {
+            const val = customFieldValues[field.id];
+            if (val === undefined) return;
+            if (field.type === "grid") {
               // Map row indices to row labels
-              const rowMap = val as Record<number, string>
-              const labeled: Record<string, string> = {}
-              ;(field.rows || []).forEach((row, ri) => {
-                if (rowMap[ri] !== undefined) labeled[row] = rowMap[ri]
-              })
-              metadata[field.label] = labeled
+              const rowMap = val as Record<number, string>;
+              const labeled: Record<string, string> = {};
+              (field.rows || []).forEach((row, ri) => {
+                if (rowMap[ri] !== undefined) labeled[row] = rowMap[ri];
+              });
+              metadata[field.label] = labeled;
             } else {
-              metadata[field.label] = val
+              metadata[field.label] = val;
             }
-          })
+          });
         }
-      })
+      });
 
-      const res = await fetch('/api/v1/public/reviews', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const res = await fetch("/api/v1/public/reviews", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           formId: form.publicId,
           content,
@@ -170,179 +192,194 @@ export default function PublicFormPage() {
           authorTitle,
           authorUrl,
           rating,
-          metadata: Object.keys(metadata).length > 0 ? metadata : undefined
-        })
-      })
+          metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+        }),
+      });
       if (res.ok) {
         // Find success step if it exists, otherwise just show success UI
-        const successIdx = steps.findIndex(s => s.type === 'success')
+        const successIdx = steps.findIndex((s) => s.type === "success");
         if (successIdx !== -1) {
-          setCurrentStepIndex(successIdx)
+          setCurrentStepIndex(successIdx);
         } else {
-           // Fallback to last step
-           setCurrentStepIndex(steps.length - 1)
+          // Fallback to last step
+          setCurrentStepIndex(steps.length - 1);
         }
       } else {
-        const data = await res.json()
-        alert(typeof data.error === 'string' ? data.error : "An error occurred while sending.")
+        const data = await res.json();
+        alert(
+          typeof data.error === "string"
+            ? data.error
+            : "An error occurred while sending.",
+        );
       }
     } catch (error) {
-      console.error("Submission failed", error)
-      alert("Network error. Please try again.")
+      console.error("Submission failed", error);
+      alert("Network error. Please try again.");
     } finally {
-      setSubmitting(false)
+      setSubmitting(false);
     }
-  }
+  };
 
-  if (loading) return (
-    <div className="min-h-screen bg-[#F9FAFB] flex items-center justify-center">
-      <Loader2 className="animate-spin text-gray-400" size={32} />
-    </div>
-  )
+  if (loading)
+    return (
+      <div className="min-h-screen bg-[#F9FAFB] flex items-center justify-center">
+        <Loader2 className="animate-spin text-gray-400" size={32} />
+      </div>
+    );
 
-  if (error || !form) return (
-    <div className="min-h-screen bg-[#F9FAFB] flex flex-col items-center justify-center p-6 text-center">
-      <h1 className="text-2xl font-bold text-gray-900 mb-2">Oops!</h1>
-      <p className="text-gray-600">{error || 'The form could not be found.'}</p>
-    </div>
-  )
+  if (error || !form)
+    return (
+      <div className="min-h-screen bg-[#F9FAFB] flex flex-col items-center justify-center p-6 text-center">
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">Oops!</h1>
+        <p className="text-gray-600">
+          {error || "The form could not be found."}
+        </p>
+      </div>
+    );
 
   return (
-    <div className="min-h-screen bg-[#F9FAFB] flex flex-col items-center justify-center p-6" style={{ fontFamily: appliedBodyFont }}>
-      <div className="w-full max-w-xl bg-white rounded-[3rem] overflow-hidden border border-gray-100 flex flex-col min-h-162.5 relative transition-all duration-500">
+    <div
+      className="min-h-screen bg-[#F9FAFB] flex flex-col items-center justify-center p-6"
+      style={{ fontFamily: appliedBodyFont }}
+    >
+      <div className="w-full max-w-xl bg-white rounded-2xl overflow-hidden border border-gray-100 flex flex-col min-h-162.5 relative transition-all duration-500">
         {/* Progress Bar */}
         <div className="h-1.5 w-full bg-gray-50 flex">
-          <div 
-            className="h-full transition-all duration-700 ease-out" 
-            style={{ 
+          <div
+            className="h-full transition-all duration-700 ease-out"
+            style={{
               backgroundColor: primaryColor,
-              width: `${((currentStepIndex + 1) / steps.length) * 100}%` 
+              width: `${((currentStepIndex + 1) / steps.length) * 100}%`,
             }}
           />
         </div>
 
-        <div className="flex-1 flex flex-col items-center justify-center p-10 md:p-16 text-center w-full">
+        <div className="flex-1 flex flex-col items-center justify-center p-6 md:p-10 text-center w-full">
           {/* Logo Rendering */}
           {branding?.logoUrl && (
-            <div className="mb-8 flex justify-center w-full animate-in fade-in duration-700">
-              <img src={branding.logoUrl} alt="Logo" className="max-h-16 object-contain pointer-events-none" />
+            <div className="mb-5 flex justify-center w-full animate-in fade-in duration-700">
+              <img
+                src={branding.logoUrl}
+                alt="Logo"
+                className="max-h-10 object-contain pointer-events-none"
+              />
             </div>
           )}
 
           {/* Step Rendering */}
-          {currentStep?.type === 'welcome' && (
-            <WelcomeStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              onNext={handleNext} 
+          {currentStep?.type === "welcome" && (
+            <WelcomeStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              onNext={handleNext}
             />
           )}
 
-          {currentStep?.type === 'informative' && (
-            <InformativeStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              onNext={handleNext} 
+          {currentStep?.type === "informative" && (
+            <InformativeStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              onNext={handleNext}
             />
           )}
 
-          {currentStep?.type === 'rating' && (
-            <RatingStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              rating={rating} 
-              setRating={setRating} 
-              onNext={handleNext} 
+          {currentStep?.type === "rating" && (
+            <RatingStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              rating={rating}
+              setRating={setRating}
+              onNext={handleNext}
             />
           )}
 
-          {currentStep?.type === 'textarea' && (
-            <TextareaStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              content={content} 
-              setContent={setContent} 
-              onNext={handleNext} 
-              onBack={() => setCurrentStepIndex(prev => prev - 1)} 
+          {currentStep?.type === "textarea" && (
+            <TextareaStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              content={content}
+              setContent={setContent}
+              onNext={handleNext}
+              onBack={() => setCurrentStepIndex((prev) => prev - 1)}
             />
           )}
 
-          {currentStep?.type === 'attribution' && (
-            <AttributionStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              authorName={authorName} 
-              setAuthorName={setAuthorName} 
-              authorEmail={authorEmail} 
-              setAuthorEmail={setAuthorEmail} 
-              authorTitle={authorTitle} 
-              setAuthorTitle={setAuthorTitle} 
-              authorUrl={authorUrl} 
-              setAuthorUrl={setAuthorUrl} 
-              submitting={submitting} 
-              onNext={handleNext} 
-              onBack={() => setCurrentStepIndex(prev => prev - 1)} 
+          {currentStep?.type === "attribution" && (
+            <AttributionStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              authorName={authorName}
+              setAuthorName={setAuthorName}
+              authorEmail={authorEmail}
+              setAuthorEmail={setAuthorEmail}
+              authorTitle={authorTitle}
+              setAuthorTitle={setAuthorTitle}
+              authorUrl={authorUrl}
+              setAuthorUrl={setAuthorUrl}
+              submitting={submitting}
+              onNext={handleNext}
+              onBack={() => setCurrentStepIndex((prev) => prev - 1)}
             />
           )}
 
-          {currentStep?.type === 'core' && (
-            <CoreStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              rating={rating} 
-              setRating={setRating} 
-              content={content} 
-              setContent={setContent} 
-              onNext={handleNext} 
+          {currentStep?.type === "core" && (
+            <CoreStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              rating={rating}
+              setRating={setRating}
+              content={content}
+              setContent={setContent}
+              onNext={handleNext}
             />
           )}
 
-          {currentStep?.type === 'identity' && (
-            <IdentityStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              authorName={authorName} 
-              setAuthorName={setAuthorName} 
-              authorEmail={authorEmail} 
-              setAuthorEmail={setAuthorEmail} 
-              authorTitle={authorTitle} 
-              setAuthorTitle={setAuthorTitle} 
-              authorUrl={authorUrl} 
-              setAuthorUrl={setAuthorUrl} 
-              submitting={submitting} 
-              onNext={handleNext} 
-              onBack={() => setCurrentStepIndex(prev => prev - 1)} 
+          {currentStep?.type === "identity" && (
+            <IdentityStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              authorName={authorName}
+              setAuthorName={setAuthorName}
+              authorEmail={authorEmail}
+              setAuthorEmail={setAuthorEmail}
+              authorTitle={authorTitle}
+              setAuthorTitle={setAuthorTitle}
+              authorUrl={authorUrl}
+              setAuthorUrl={setAuthorUrl}
+              submitting={submitting}
+              onNext={handleNext}
+              onBack={() => setCurrentStepIndex((prev) => prev - 1)}
             />
           )}
 
-          {currentStep?.type === 'custom' && (
-            <CustomStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
-              customFieldValues={customFieldValues} 
-              setCustomFieldValues={setCustomFieldValues} 
-              onNext={handleNext} 
-              onBack={() => setCurrentStepIndex(prev => prev - 1)} 
+          {currentStep?.type === "custom" && (
+            <CustomStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
+              customFieldValues={customFieldValues}
+              setCustomFieldValues={setCustomFieldValues}
+              onNext={handleNext}
+              onBack={() => setCurrentStepIndex((prev) => prev - 1)}
             />
           )}
 
-          {currentStep?.type === 'success' && (
-            <SuccessStep 
-              step={currentStep} 
-              primaryColor={primaryColor} 
-              appliedHeadingFont={appliedHeadingFont} 
+          {currentStep?.type === "success" && (
+            <SuccessStep
+              step={currentStep}
+              primaryColor={primaryColor}
+              appliedHeadingFont={appliedHeadingFont}
             />
           )}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/AttributionStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/AttributionStep.tsx
@@ -1,110 +1,126 @@
-import { ArrowLeft, Plus, Loader2 } from 'lucide-react'
-import type { FormStep } from '../types'
+import { ArrowLeft, Plus, Loader2 } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface AttributionStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  authorName: string
-  authorEmail: string
-  authorTitle: string
-  authorUrl: string
-  submitting: boolean
-  setAuthorName: (name: string) => void
-  setAuthorEmail: (email: string) => void
-  setAuthorTitle: (title: string) => void
-  setAuthorUrl: (url: string) => void
-  onNext: () => void
-  onBack: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  authorName: string;
+  authorEmail: string;
+  authorTitle: string;
+  authorUrl: string;
+  submitting: boolean;
+  setAuthorName: (name: string) => void;
+  setAuthorEmail: (email: string) => void;
+  setAuthorTitle: (title: string) => void;
+  setAuthorUrl: (url: string) => void;
+  onNext: () => void;
+  onBack: () => void;
 }
 
-export function AttributionStep({ 
-  step, 
-  primaryColor, 
-  appliedHeadingFont, 
-  authorName, 
-  authorEmail, 
-  authorTitle, 
-  authorUrl, 
+export function AttributionStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  authorName,
+  authorEmail,
+  authorTitle,
+  authorUrl,
   submitting,
   setAuthorName,
   setAuthorEmail,
   setAuthorTitle,
   setAuthorUrl,
-  onNext, 
-  onBack 
+  onNext,
+  onBack,
 }: AttributionStepProps) {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-10 text-xl leading-relaxed">{step.description}</p>
-      
-      <div className="w-full space-y-4 mb-10">
-        <div className="flex flex-col gap-4">
-          <div className="w-full h-32 rounded-[2rem] bg-gray-50 border-2 border-dashed border-gray-100 flex flex-col items-center justify-center gap-2 text-gray-500 hover:bg-gray-100 hover:border-gray-200 transition-all cursor-pointer group">
-            <Plus size={32} className="group-hover:scale-110 transition-transform" />
-            <span className="text-xs font-black uppercase tracking-widest">Add a photo</span>
+      <p className="text-gray-600 mb-6 text-base leading-relaxed">
+        {step.description}
+      </p>
+
+      <div className="w-full space-y-3 mb-6">
+        <div className="flex flex-col gap-3">
+          <div className="w-full h-24 rounded-xl bg-gray-50 border-2 border-dashed border-gray-100 flex flex-col items-center justify-center gap-1.5 text-gray-500 hover:bg-gray-100 hover:border-gray-200 transition-all cursor-pointer group">
+            <Plus
+              size={24}
+              className="group-hover:scale-110 transition-transform"
+            />
+            <span className="text-xs font-black uppercase tracking-widest">
+              Add a photo
+            </span>
           </div>
-          
+
           <input
             required
             type="text"
             placeholder="Your full name"
             value={authorName}
             onChange={(e) => setAuthorName(e.target.value)}
-            className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+            className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
           />
         </div>
 
-        {(step.config as Record<string, string | boolean>)?.collectEmail !== false && (
+        {(step.config as Record<string, string | boolean>)?.collectEmail !==
+          false && (
           <input
             required
             type="email"
             placeholder="votre@email.com"
             value={authorEmail}
             onChange={(e) => setAuthorEmail(e.target.value)}
-            className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+            className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
           />
         )}
 
         {(step.config as Record<string, string | boolean>)?.collectCompany && (
-          <div className="flex gap-4">
+          <div className="flex gap-3">
             <input
               type="text"
               placeholder="Your company"
               value={authorTitle}
               onChange={(e) => setAuthorTitle(e.target.value)}
-              className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+              className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
             />
             <input
               type="url"
               placeholder="Website"
               value={authorUrl}
               onChange={(e) => setAuthorUrl(e.target.value)}
-              className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+              className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
             />
           </div>
         )}
       </div>
 
-      <div className="flex gap-4 w-full">
-         <button 
+      <div className="flex gap-3 w-full">
+        <button
           onClick={onBack}
-          className="px-6 py-5 rounded-2xl bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-700 transition-all font-bold"
+          className="px-5 py-3 rounded-xl bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-700 transition-all font-bold"
         >
-          <ArrowLeft size={22} />
+          <ArrowLeft size={18} />
         </button>
-        <button 
+        <button
           disabled={!authorName || submitting}
           onClick={onNext}
-          style={{ backgroundColor: authorName ? primaryColor : '#E5E7EB' }}
-          className="flex-1 py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-3"
+          style={{ backgroundColor: authorName ? primaryColor : "#E5E7EB" }}
+          className="flex-1 py-3 rounded-xl text-white font-bold text-sm shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-2"
         >
-          {submitting ? <Loader2 size={28} className="animate-spin" /> : (step.config as Record<string, string | boolean>)?.buttonText || 'Finish'}
+          {submitting ? (
+            <Loader2 size={20} className="animate-spin" />
+          ) : (
+            (step.config as Record<string, string | boolean>)?.buttonText ||
+            "Finish"
+          )}
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/CoreStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/CoreStep.tsx
@@ -1,66 +1,89 @@
-import { Star, ArrowRight } from 'lucide-react'
-import type { FormStep } from '../types'
+import { Star, ArrowRight } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface CoreStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  rating: number
-  setRating: (rating: number) => void
-  content: string
-  setContent: (content: string) => void
-  onNext: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  rating: number;
+  setRating: (rating: number) => void;
+  content: string;
+  setContent: (content: string) => void;
+  onNext: () => void;
 }
 
-export function CoreStep({ 
-  step, 
-  primaryColor, 
-  appliedHeadingFont, 
-  rating, 
-  setRating, 
-  content, 
-  setContent, 
-  onNext 
+export function CoreStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  rating,
+  setRating,
+  content,
+  setContent,
+  onNext,
 }: CoreStepProps) {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-8 text-xl leading-relaxed">{step.description}</p>
+      <p className="text-gray-600 mb-6 text-base leading-relaxed">
+        {step.description}
+      </p>
 
-      <div className="flex gap-4 justify-center mb-8">
-        {(step.config as Record<string, string | boolean>)?.ratingType === 'emojis' ? (
-          ['😠', '🙁', '😐', '🙂', '😍'].map((emoji, i) => (
-            <button key={i} onClick={() => setRating(i + 1)}
-              className={`text-5xl transition-all hover:scale-125 ${rating === i + 1 ? 'scale-125 grayscale-0' : 'grayscale opacity-40 hover:opacity-100 hover:grayscale-0'}`}
-            >{emoji}</button>
-          ))
-        ) : (
-          [1, 2, 3, 4, 5].map((val) => (
-            <button key={val} onClick={() => setRating(val)} className="p-1 transition-all hover:scale-110 group focus:outline-none">
-              <Star size={52} className={`transition-all ${rating >= val ? 'fill-yellow-400 text-yellow-400' : 'text-gray-300 group-hover:text-gray-400 fill-gray-200'}`} />
-            </button>
-          ))
-        )}
+      <div className="flex gap-3 justify-center mb-6">
+        {(step.config as Record<string, string | boolean>)?.ratingType ===
+        "emojis"
+          ? ["😠", "🙁", "😐", "🙂", "😍"].map((emoji, i) => (
+              <button
+                key={i}
+                onClick={() => setRating(i + 1)}
+                className={`text-3xl transition-all hover:scale-125 ${rating === i + 1 ? "scale-125 grayscale-0" : "grayscale opacity-40 hover:opacity-100 hover:grayscale-0"}`}
+              >
+                {emoji}
+              </button>
+            ))
+          : [1, 2, 3, 4, 5].map((val) => (
+              <button
+                key={val}
+                onClick={() => setRating(val)}
+                className="p-1 transition-all hover:scale-110 group focus:outline-none"
+              >
+                <Star
+                  size={36}
+                  className={`transition-all ${rating >= val ? "fill-yellow-400 text-yellow-400" : "text-gray-300 group-hover:text-gray-400 fill-gray-200"}`}
+                />
+              </button>
+            ))}
       </div>
 
       <textarea
         autoFocus
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        placeholder={((step.config as Record<string, string | boolean>)?.placeholder as string) || 'Tell us more about your experience...'}
-        className="w-full h-40 p-8 rounded-[2rem] border-2 border-gray-100 bg-gray-50 mb-8 focus:ring-4 focus:ring-gray-100 focus:border-gray-200 outline-none transition-all text-black text-lg resize-none placeholder:text-gray-400"
+        placeholder={
+          ((step.config as Record<string, string | boolean>)
+            ?.placeholder as string) || "Tell us more about your experience..."
+        }
+        className="w-full h-32 p-4 rounded-xl border-2 border-gray-100 bg-gray-50 mb-6 focus:ring-4 focus:ring-gray-100 focus:border-gray-200 outline-none transition-all text-black text-sm resize-none placeholder:text-gray-400"
       />
 
       <button
         disabled={rating === 0 || content.length < 5}
         onClick={onNext}
-        style={{ backgroundColor: (rating > 0 && content.length >= 5) ? primaryColor : '#E5E7EB' }}
-        className="w-full py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:cursor-not-allowed flex items-center justify-center gap-3"
+        style={{
+          backgroundColor:
+            rating > 0 && content.length >= 5 ? primaryColor : "#E5E7EB",
+        }}
+        className="w-full py-3 rounded-xl text-white font-bold text-sm shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:cursor-not-allowed flex items-center justify-center gap-2"
       >
-        {(step.config as Record<string, string | boolean>)?.buttonText || 'Continue'} <ArrowRight size={22} />
+        {(step.config as Record<string, string | boolean>)?.buttonText ||
+          "Continue"}{" "}
+        <ArrowRight size={18} />
       </button>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/CustomStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/CustomStep.tsx
@@ -1,115 +1,189 @@
-import { ArrowRight, ArrowLeft } from 'lucide-react'
-import type { FormStep, StepField } from '../types'
+import { ArrowRight, ArrowLeft } from "lucide-react";
+import type { FormStep, StepField } from "../types";
 
 interface CustomStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  customFieldValues: Record<string, unknown>
-  setCustomFieldValues: (values: Record<string, unknown> | ((prev: Record<string, unknown>) => Record<string, unknown>)) => void
-  onNext: () => void
-  onBack: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  customFieldValues: Record<string, unknown>;
+  setCustomFieldValues: (
+    values:
+      | Record<string, unknown>
+      | ((prev: Record<string, unknown>) => Record<string, unknown>),
+  ) => void;
+  onNext: () => void;
+  onBack: () => void;
 }
 
-export function CustomStep({ 
-  step, 
-  primaryColor, 
-  appliedHeadingFont, 
-  customFieldValues, 
-  setCustomFieldValues, 
-  onNext, 
-  onBack 
+export function CustomStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  customFieldValues,
+  setCustomFieldValues,
+  onNext,
+  onBack,
 }: CustomStepProps) {
-  const fields = ((step.config as Record<string, unknown>)?.fields || []) as StepField[]
+  const fields = ((step.config as Record<string, unknown>)?.fields ||
+    []) as StepField[];
 
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-8 text-xl leading-relaxed">{step.description}</p>
+      <p className="text-gray-600 mb-6 text-base leading-relaxed">
+        {step.description}
+      </p>
 
-      <div className="w-full space-y-6 mb-10 text-left">
-        {fields.map(field => (
+      <div className="w-full space-y-4 mb-6 text-left">
+        {fields.map((field) => (
           <div key={field.id}>
-            <p className="text-sm font-bold text-gray-800 mb-2">{field.label}</p>
-            {field.type === 'text' && (
+            <p className="text-sm font-bold text-gray-800 mb-1.5">
+              {field.label}
+            </p>
+            {field.type === "text" && (
               <input
                 type="text"
-                placeholder={field.placeholder || 'Your answer...'}
-                value={(customFieldValues[field.id] as string) || ''}
-                onChange={e => setCustomFieldValues(prev => ({ ...prev, [field.id]: e.target.value }))}
-                className="w-full px-6 py-4 rounded-2xl border-2 border-gray-100 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-black placeholder:text-gray-400"
+                placeholder={field.placeholder || "Your answer..."}
+                value={(customFieldValues[field.id] as string) || ""}
+                onChange={(e) =>
+                  setCustomFieldValues((prev) => ({
+                    ...prev,
+                    [field.id]: e.target.value,
+                  }))
+                }
+                className="w-full px-4 py-2.5 rounded-xl border-2 border-gray-100 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
               />
             )}
-            {field.type === 'nps' && (
+            {field.type === "nps" && (
               <div className="flex gap-1">
                 {Array.from({ length: 11 }, (_, i) => {
-                  const selected = customFieldValues[field.id] === i
+                  const selected = customFieldValues[field.id] === i;
                   return (
-                    <button key={i}
-                      onClick={() => setCustomFieldValues(prev => ({ ...prev, [field.id]: i }))}
-                      style={selected ? { backgroundColor: primaryColor, borderColor: primaryColor, color: '#fff' } : {}}
-                      className={`flex-1 py-3 rounded-xl border-2 text-sm font-bold transition-all ${selected ? '' : 'border-gray-100 bg-gray-50 hover:border-gray-300 text-gray-600'}`}
-                    >{i}</button>
-                  )
+                    <button
+                      key={i}
+                      onClick={() =>
+                        setCustomFieldValues((prev) => ({
+                          ...prev,
+                          [field.id]: i,
+                        }))
+                      }
+                      style={
+                        selected
+                          ? {
+                              backgroundColor: primaryColor,
+                              borderColor: primaryColor,
+                              color: "#fff",
+                            }
+                          : {}
+                      }
+                      className={`flex-1 py-2 rounded-lg border-2 text-xs font-bold transition-all ${selected ? "" : "border-gray-100 bg-gray-50 hover:border-gray-300 text-gray-600"}`}
+                    >
+                      {i}
+                    </button>
+                  );
                 })}
               </div>
             )}
-            {field.type === 'choice' && (
-              <div className="space-y-2">
+            {field.type === "choice" && (
+              <div className="space-y-1.5">
                 {(field.options || []).map((opt, i) => {
-                  const selected = customFieldValues[field.id] === opt
+                  const selected = customFieldValues[field.id] === opt;
                   return (
-                    <button key={i}
-                      onClick={() => setCustomFieldValues(prev => ({ ...prev, [field.id]: opt }))}
+                    <button
+                      key={i}
+                      onClick={() =>
+                        setCustomFieldValues((prev) => ({
+                          ...prev,
+                          [field.id]: opt,
+                        }))
+                      }
                       style={selected ? { borderColor: primaryColor } : {}}
-                      className={`w-full px-6 py-4 rounded-2xl border-2 text-left font-medium transition-all flex items-center gap-3 ${selected ? 'bg-gray-50 text-gray-900' : 'border-gray-100 bg-gray-50 hover:border-gray-300 text-gray-700'}`}
+                      className={`w-full px-4 py-2.5 rounded-xl border-2 text-left text-sm font-medium transition-all flex items-center gap-2.5 ${selected ? "bg-gray-50 text-gray-900" : "border-gray-100 bg-gray-50 hover:border-gray-300 text-gray-700"}`}
                     >
                       <div
-                        style={selected ? { backgroundColor: primaryColor, borderColor: primaryColor } : {}}
-                        className={`w-4 h-4 rounded-full border-2 shrink-0 ${selected ? '' : 'border-gray-300'}`}
+                        style={
+                          selected
+                            ? {
+                                backgroundColor: primaryColor,
+                                borderColor: primaryColor,
+                              }
+                            : {}
+                        }
+                        className={`w-3.5 h-3.5 rounded-full border-2 shrink-0 ${selected ? "" : "border-gray-300"}`}
                       />
                       {opt}
                     </button>
-                  )
+                  );
                 })}
               </div>
             )}
-            {field.type === 'grid' && (
+            {field.type === "grid" && (
               <div className="overflow-x-auto">
-                <table className="w-full text-sm border-collapse">
+                <table className="w-full text-xs border-collapse">
                   <thead>
                     <tr>
-                      <th className="p-2 text-gray-400 font-normal text-left w-1/3" />
-                      {(field.options || ['1','2','3','4','5']).map(col => (
-                        <th key={col} className="p-2 text-gray-500 font-bold text-center">{col}</th>
-                      ))}
+                      <th className="p-1.5 text-gray-400 font-normal text-left w-1/3" />
+                      {(field.options || ["1", "2", "3", "4", "5"]).map(
+                        (col) => (
+                          <th
+                            key={col}
+                            className="p-1.5 text-gray-500 font-bold text-center"
+                          >
+                            {col}
+                          </th>
+                        ),
+                      )}
                     </tr>
                   </thead>
                   <tbody>
                     {(field.rows || []).map((row, ri) => {
-                      const rowSelections = (customFieldValues[field.id] as Record<number, string>) || {}
+                      const rowSelections =
+                        (customFieldValues[field.id] as Record<
+                          number,
+                          string
+                        >) || {};
                       return (
                         <tr key={ri} className="border-t border-gray-100">
-                          <td className="p-2 text-gray-600 text-sm">{row}</td>
-                          {(field.options || ['1','2','3','4','5']).map(col => {
-                            const selected = rowSelections[ri] === col
-                            return (
-                              <td key={col} className="p-2 text-center">
-                                <button
-                                  onClick={() => setCustomFieldValues(prev => ({
-                                    ...prev,
-                                    [field.id]: { ...((prev[field.id] as Record<number, string>) || {}), [ri]: col }
-                                  }))}
-                                  style={selected ? { backgroundColor: primaryColor, borderColor: primaryColor } : {}}
-                                  className={`w-5 h-5 rounded-full border-2 mx-auto transition-all block ${selected ? '' : 'border-gray-200 hover:border-gray-400'}`}
-                                />
-                              </td>
-                            )
-                          })}
+                          <td className="p-1.5 text-gray-600 text-xs">{row}</td>
+                          {(field.options || ["1", "2", "3", "4", "5"]).map(
+                            (col) => {
+                              const selected = rowSelections[ri] === col;
+                              return (
+                                <td key={col} className="p-1.5 text-center">
+                                  <button
+                                    onClick={() =>
+                                      setCustomFieldValues((prev) => ({
+                                        ...prev,
+                                        [field.id]: {
+                                          ...((prev[field.id] as Record<
+                                            number,
+                                            string
+                                          >) || {}),
+                                          [ri]: col,
+                                        },
+                                      }))
+                                    }
+                                    style={
+                                      selected
+                                        ? {
+                                            backgroundColor: primaryColor,
+                                            borderColor: primaryColor,
+                                          }
+                                        : {}
+                                    }
+                                    className={`w-4 h-4 rounded-full border-2 mx-auto transition-all block ${selected ? "" : "border-gray-200 hover:border-gray-400"}`}
+                                  />
+                                </td>
+                              );
+                            },
+                          )}
                         </tr>
-                      )
+                      );
                     })}
                   </tbody>
                 </table>
@@ -119,20 +193,22 @@ export function CustomStep({
         ))}
       </div>
 
-      <div className="flex gap-4 w-full">
-        <button onClick={onBack}
-          className="px-6 py-5 rounded-2xl bg-gray-100 text-gray-600 hover:bg-gray-200 transition-all font-bold"
+      <div className="flex gap-3 w-full">
+        <button
+          onClick={onBack}
+          className="px-5 py-3 rounded-xl bg-gray-100 text-gray-600 hover:bg-gray-200 transition-all font-bold"
         >
-          <ArrowLeft size={22} />
+          <ArrowLeft size={18} />
         </button>
         <button
           onClick={onNext}
           style={{ backgroundColor: primaryColor }}
-          className="flex-1 py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center justify-center gap-3"
+          className="flex-1 py-3 rounded-xl text-white font-bold text-sm shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center justify-center gap-2"
         >
-          {(step.config as Record<string, string>)?.buttonText || 'Continue'} <ArrowRight size={22} />
+          {(step.config as Record<string, string>)?.buttonText || "Continue"}{" "}
+          <ArrowRight size={18} />
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/IdentityStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/IdentityStep.tsx
@@ -1,50 +1,60 @@
-import { ArrowLeft, Plus, Loader2 } from 'lucide-react'
-import type { FormStep } from '../types'
+import { ArrowLeft, Plus, Loader2 } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface IdentityStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  authorName: string
-  authorEmail: string
-  authorTitle: string
-  authorUrl: string
-  submitting: boolean
-  setAuthorName: (name: string) => void
-  setAuthorEmail: (email: string) => void
-  setAuthorTitle: (title: string) => void
-  setAuthorUrl: (url: string) => void
-  onNext: () => void
-  onBack: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  authorName: string;
+  authorEmail: string;
+  authorTitle: string;
+  authorUrl: string;
+  submitting: boolean;
+  setAuthorName: (name: string) => void;
+  setAuthorEmail: (email: string) => void;
+  setAuthorTitle: (title: string) => void;
+  setAuthorUrl: (url: string) => void;
+  onNext: () => void;
+  onBack: () => void;
 }
 
-export function IdentityStep({ 
-  step, 
-  primaryColor, 
-  appliedHeadingFont, 
-  authorName, 
-  authorEmail, 
-  authorTitle, 
-  authorUrl, 
+export function IdentityStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  authorName,
+  authorEmail,
+  authorTitle,
+  authorUrl,
   submitting,
   setAuthorName,
   setAuthorEmail,
   setAuthorTitle,
   setAuthorUrl,
-  onNext, 
-  onBack 
+  onNext,
+  onBack,
 }: IdentityStepProps) {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-10 text-xl leading-relaxed">{step.description}</p>
+      <p className="text-gray-600 mb-6 text-base leading-relaxed">
+        {step.description}
+      </p>
 
-      <div className="w-full space-y-4 mb-10">
-        <div className="w-full h-28 rounded-[2rem] bg-gray-50 border-2 border-dashed border-gray-100 flex flex-col items-center justify-center gap-2 text-gray-500 hover:bg-gray-100 transition-all cursor-pointer group">
-          <Plus size={28} className="group-hover:scale-110 transition-transform" />
-          <span className="text-xs font-black uppercase tracking-widest">Add a photo</span>
+      <div className="w-full space-y-3 mb-6">
+        <div className="w-full h-20 rounded-xl bg-gray-50 border-2 border-dashed border-gray-100 flex flex-col items-center justify-center gap-1.5 text-gray-500 hover:bg-gray-100 transition-all cursor-pointer group">
+          <Plus
+            size={22}
+            className="group-hover:scale-110 transition-transform"
+          />
+          <span className="text-xs font-black uppercase tracking-widest">
+            Add a photo
+          </span>
         </div>
         <input
           required
@@ -52,7 +62,7 @@ export function IdentityStep({
           placeholder="Your full name"
           value={authorName}
           onChange={(e) => setAuthorName(e.target.value)}
-          className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+          className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
         />
         {(step.config as Record<string, boolean>)?.collectEmail !== false && (
           <input
@@ -60,24 +70,24 @@ export function IdentityStep({
             placeholder="votre@email.com"
             value={authorEmail}
             onChange={(e) => setAuthorEmail(e.target.value)}
-            className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+            className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 focus:border-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
           />
         )}
         {(step.config as Record<string, boolean>)?.collectCompany && (
-          <div className="flex gap-4">
+          <div className="flex gap-3">
             <input
               type="text"
               placeholder="Your company"
               value={authorTitle}
               onChange={(e) => setAuthorTitle(e.target.value)}
-              className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+              className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
             />
             <input
               type="url"
               placeholder="Website"
               value={authorUrl}
               onChange={(e) => setAuthorUrl(e.target.value)}
-              className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+              className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
             />
           </div>
         )}
@@ -87,26 +97,31 @@ export function IdentityStep({
             placeholder="linkedin.com/in/yourprofile"
             value={authorUrl}
             onChange={(e) => setAuthorUrl(e.target.value)}
-            className="w-full px-8 py-5 rounded-2xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-lg text-black placeholder:text-gray-400"
+            className="w-full px-4 py-3 rounded-xl border-2 border-gray-50 bg-gray-50 focus:bg-white focus:ring-4 focus:ring-gray-100 outline-none transition-all text-sm text-black placeholder:text-gray-400"
           />
         )}
       </div>
 
-      <div className="flex gap-4 w-full">
-        <button onClick={onBack}
-          className="px-6 py-5 rounded-2xl bg-gray-100 text-gray-600 hover:bg-gray-200 transition-all font-bold"
+      <div className="flex gap-3 w-full">
+        <button
+          onClick={onBack}
+          className="px-5 py-3 rounded-xl bg-gray-100 text-gray-600 hover:bg-gray-200 transition-all font-bold"
         >
-          <ArrowLeft size={22} />
+          <ArrowLeft size={18} />
         </button>
         <button
           disabled={!authorName || submitting}
           onClick={onNext}
-          style={{ backgroundColor: authorName ? primaryColor : '#E5E7EB' }}
-          className="flex-1 py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-3"
+          style={{ backgroundColor: authorName ? primaryColor : "#E5E7EB" }}
+          className="flex-1 py-3 rounded-xl text-white font-bold text-sm shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-2"
         >
-          {submitting ? <Loader2 size={28} className="animate-spin" /> : ((step.config as Record<string, string>)?.buttonText || 'Submit')}
+          {submitting ? (
+            <Loader2 size={20} className="animate-spin" />
+          ) : (
+            (step.config as Record<string, string>)?.buttonText || "Submit"
+          )}
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/InformativeStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/InformativeStep.tsx
@@ -1,29 +1,39 @@
-import { ArrowRight } from 'lucide-react'
-import type { FormStep } from '../types'
+import { ArrowRight } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface InformativeStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  onNext: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  onNext: () => void;
 }
 
-export function InformativeStep({ step, primaryColor, appliedHeadingFont, onNext }: InformativeStepProps) {
+export function InformativeStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  onNext,
+}: InformativeStepProps) {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-10 text-xl leading-relaxed max-w-md">
+      <p className="text-gray-600 mb-6 text-base leading-relaxed max-w-md">
         {step.description}
       </p>
-      <button 
+      <button
         onClick={onNext}
         style={{ backgroundColor: primaryColor }}
-        className="w-full py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center justify-center gap-3"
+        className="w-full py-3 rounded-xl text-white font-bold text-sm shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center justify-center gap-2"
       >
-        {(step.config as Record<string, string | boolean>)?.buttonText || 'Continue'} <ArrowRight size={22} />
+        {(step.config as Record<string, string | boolean>)?.buttonText ||
+          "Continue"}{" "}
+        <ArrowRight size={18} />
       </button>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/RatingStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/RatingStep.tsx
@@ -1,64 +1,71 @@
-import { Star, ArrowRight } from 'lucide-react'
-import type { FormStep } from '../types'
+import { Star, ArrowRight } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface RatingStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  rating: number
-  setRating: (rating: number) => void
-  onNext: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  rating: number;
+  setRating: (rating: number) => void;
+  onNext: () => void;
 }
 
-export function RatingStep({ 
-  step, 
-  primaryColor, 
-  appliedHeadingFont, 
-  rating, 
-  setRating, 
-  onNext 
+export function RatingStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  rating,
+  setRating,
+  onNext,
 }: RatingStepProps) {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-10 text-xl leading-relaxed">{step.description}</p>
-      
-      <div className="flex gap-4 justify-center mb-12">
-        {(step.config as Record<string, string | boolean>)?.ratingType === 'emojis' ? (
-          ['😠', '🙁', '😐', '🙂', '😍'].map((emoji, i) => (
-            <button
-              key={i}
-              onClick={() => setRating(i + 1)}
-              className={`text-5xl transition-all hover:scale-125 ${rating === i + 1 ? 'scale-125 grayscale-0' : 'grayscale opacity-40 hover:opacity-100 hover:grayscale-0'}`}
-            >
-              {emoji}
-            </button>
-          ))
-        ) : (
-          [1, 2, 3, 4, 5].map((val) => (
-            <button
-              key={val}
-              onClick={() => setRating(val)}
-              className="p-1 transition-all hover:scale-110 group focus:outline-none"
-            >
-              <Star 
-                size={52} 
-                className={`transition-all ${rating >= val ? 'fill-yellow-400 text-yellow-400' : 'text-gray-300 group-hover:text-gray-400 fill-gray-200'}`} 
-              />
-            </button>
-          )))}
+      <p className="text-gray-600 mb-6 text-base leading-relaxed">
+        {step.description}
+      </p>
+
+      <div className="flex gap-3 justify-center mb-8">
+        {(step.config as Record<string, string | boolean>)?.ratingType ===
+        "emojis"
+          ? ["😠", "🙁", "😐", "🙂", "😍"].map((emoji, i) => (
+              <button
+                key={i}
+                onClick={() => setRating(i + 1)}
+                className={`text-3xl transition-all hover:scale-125 ${rating === i + 1 ? "scale-125 grayscale-0" : "grayscale opacity-40 hover:opacity-100 hover:grayscale-0"}`}
+              >
+                {emoji}
+              </button>
+            ))
+          : [1, 2, 3, 4, 5].map((val) => (
+              <button
+                key={val}
+                onClick={() => setRating(val)}
+                className="p-1 transition-all hover:scale-110 group focus:outline-none"
+              >
+                <Star
+                  size={36}
+                  className={`transition-all ${rating >= val ? "fill-yellow-400 text-yellow-400" : "text-gray-300 group-hover:text-gray-400 fill-gray-200"}`}
+                />
+              </button>
+            ))}
       </div>
 
-      <button 
+      <button
         disabled={rating === 0}
         onClick={onNext}
-        style={{ backgroundColor: rating > 0 ? primaryColor : '#E5E7EB' }}
-        className="w-full py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:cursor-not-allowed flex items-center justify-center gap-3"
+        style={{ backgroundColor: rating > 0 ? primaryColor : "#E5E7EB" }}
+        className="w-full py-3 rounded-xl text-white font-bold text-sm shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:cursor-not-allowed flex items-center justify-center gap-2"
       >
-        {(step.config as Record<string, string | boolean>)?.buttonText || 'Continue'} <ArrowRight size={22} />
+        {(step.config as Record<string, string | boolean>)?.buttonText ||
+          "Continue"}{" "}
+        <ArrowRight size={18} />
       </button>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/SuccessStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/SuccessStep.tsx
@@ -1,27 +1,34 @@
-import { CheckCircle } from 'lucide-react'
-import type { FormStep } from '../types'
+import { CheckCircle } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface SuccessStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
 }
 
-export function SuccessStep({ step, primaryColor, appliedHeadingFont }: SuccessStepProps) {
+export function SuccessStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+}: SuccessStepProps) {
   return (
     <div className="animate-in zoom-in-95 duration-1000 w-full flex flex-col items-center">
-      <div 
+      <div
         style={{ backgroundColor: `${primaryColor}15`, color: primaryColor }}
-        className="w-32 h-32 rounded-full flex items-center justify-center mx-auto mb-10 shadow-inner animate-bounce"
+        className="w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-6 shadow-inner animate-bounce"
       >
-        <CheckCircle size={64} />
+        <CheckCircle size={40} />
       </div>
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 text-xl leading-relaxed max-w-md">
+      <p className="text-gray-600 text-base leading-relaxed max-w-md">
         {step.description}
       </p>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/TextareaStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/TextareaStep.tsx
@@ -1,56 +1,68 @@
-import { ArrowRight, ArrowLeft } from 'lucide-react'
-import type { FormStep } from '../types'
+import { ArrowRight, ArrowLeft } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface TextareaStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  content: string
-  setContent: (content: string) => void
-  onNext: () => void
-  onBack: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  content: string;
+  setContent: (content: string) => void;
+  onNext: () => void;
+  onBack: () => void;
 }
 
-export function TextareaStep({ 
-  step, 
-  primaryColor, 
-  appliedHeadingFont, 
-  content, 
-  setContent, 
-  onNext, 
-  onBack 
+export function TextareaStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  content,
+  setContent,
+  onNext,
+  onBack,
 }: TextareaStepProps) {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-8 text-xl leading-relaxed">{step.description}</p>
-      
+      <p className="text-gray-600 mb-6 text-base leading-relaxed">
+        {step.description}
+      </p>
+
       <textarea
         autoFocus
         value={content}
         onChange={(e) => setContent(e.target.value)}
-        placeholder={((step.config as Record<string, string | boolean>)?.placeholder as string) || "Type your testimonial here..."}
-        className="w-full h-48 p-8 rounded-[2rem] border-2 border-gray-100 bg-gray-50 mb-8 focus:ring-4 focus:ring-gray-100 focus:border-gray-200 outline-none transition-all text-black text-lg resize-none placeholder:text-gray-400"
+        placeholder={
+          ((step.config as Record<string, string | boolean>)
+            ?.placeholder as string) || "Type your testimonial here..."
+        }
+        className="w-full h-36 p-4 rounded-xl border-2 border-gray-100 bg-gray-50 mb-6 focus:ring-4 focus:ring-gray-100 focus:border-gray-200 outline-none transition-all text-black text-sm resize-none placeholder:text-gray-400"
       />
 
-      <div className="flex gap-4 w-full">
-        <button 
+      <div className="flex gap-3 w-full">
+        <button
           onClick={onBack}
-          className="px-6 py-5 rounded-2xl bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-700 transition-all font-bold"
+          className="px-5 py-3 rounded-xl bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-700 transition-all font-bold"
         >
-          <ArrowLeft size={22} />
+          <ArrowLeft size={18} />
         </button>
-        <button 
+        <button
           disabled={content.length < 5}
           onClick={onNext}
-          style={{ backgroundColor: content.length >= 5 ? primaryColor : '#E5E7EB' }}
-          className="flex-1 py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-3"
+          style={{
+            backgroundColor: content.length >= 5 ? primaryColor : "#E5E7EB",
+          }}
+          className="flex-1 py-3 rounded-xl text-white font-bold text-sm shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-2"
         >
-          {(step.config as Record<string, string | boolean>)?.buttonText || 'Next'} <ArrowRight size={22} />
+          {(step.config as Record<string, string | boolean>)?.buttonText ||
+            "Next"}{" "}
+          <ArrowRight size={18} />
         </button>
       </div>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/WelcomeStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/WelcomeStep.tsx
@@ -1,29 +1,39 @@
-import { ArrowRight } from 'lucide-react'
-import type { FormStep } from '../types'
+import { ArrowRight } from "lucide-react";
+import type { FormStep } from "../types";
 
 interface WelcomeStepProps {
-  step: FormStep
-  primaryColor: string
-  appliedHeadingFont: string
-  onNext: () => void
+  step: FormStep;
+  primaryColor: string;
+  appliedHeadingFont: string;
+  onNext: () => void;
 }
 
-export function WelcomeStep({ step, primaryColor, appliedHeadingFont, onNext }: WelcomeStepProps) {
+export function WelcomeStep({
+  step,
+  primaryColor,
+  appliedHeadingFont,
+  onNext,
+}: WelcomeStepProps) {
   return (
     <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
-      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+      <h1
+        className="text-2xl font-black tracking-tighter text-black mb-4"
+        style={{ fontFamily: appliedHeadingFont, color: "#000000" }}
+      >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-10 text-xl leading-relaxed max-w-md">
+      <p className="text-gray-600 mb-22 text-base leading-relaxed max-w-md bg-red-300">
         {step.description}
       </p>
-      <button 
+      <button
         onClick={onNext}
         style={{ backgroundColor: primaryColor }}
-        className="w-full py-5 rounded-2xl text-white font-bold text-lg shadow-[0_10px_30px_rgba(0,0,0,0.1)] hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center justify-center gap-3"
+        className="w-full py-3 rounded-xl text-white font-bold text-sm shadow-[0_10px_30px_rgba(0,0,0,0.1)] hover:scale-[1.02] active:scale-[0.98] transition-all flex items-center justify-center gap-2"
       >
-        {(step.config as Record<string, string | boolean>)?.buttonText || 'Start'} <ArrowRight size={22} />
+        {(step.config as Record<string, string | boolean>)?.buttonText ||
+          "Start"}{" "}
+        <ArrowRight size={18} />
       </button>
     </div>
-  )
+  );
 }

--- a/apps/admin/src/pages/public-form/steps/WelcomeStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/WelcomeStep.tsx
@@ -22,7 +22,7 @@ export function WelcomeStep({
       >
         {step.title}
       </h1>
-      <p className="text-gray-600 mb-22 text-base leading-relaxed max-w-md bg-red-300">
+      <p className="text-gray-600 mb-6 text-base leading-relaxed max-w-md">
         {step.description}
       </p>
       <button


### PR DESCRIPTION
## What does this PR do?                                                                                              
                                                                                                                        
  Compact the public-facing form rendering to match the tight, focused feel of Typeform/Senja — smaller typography,     
  tighter padding, reduced element sizes.                                                                               
                                                                                                                        
  Closes #104 (Task 6: compact rendering)                                                                             

  ---

  ## Type of change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Breaking change
  - [ ] Documentation                                                                                                   
  - [ ] Refactor
  - [ ] Chore (deps, config, tooling)                                                                                   
                                                                                                                      
  ---

  ## Changes made

  - **Titles:** `text-4xl` → `text-2xl` across all step components                                                      
  - **Body text:** `text-xl` → `text-base`
  - **Buttons:** `py-5/text-lg/rounded-2xl` → `py-3/text-sm/rounded-xl`                                                 
  - **Inputs:** `px-8/py-5/rounded-2xl` → `px-4/py-3/rounded-xl`                                                        
  - **Textareas:** `h-40–48/p-8/rounded-[2rem]` → `h-32–36/p-4/rounded-xl`
  - **Stars:** 52px → 36px, **Emojis:** `text-5xl` → `text-3xl`                                                         
  - **Container:** `p-10/md:p-16/rounded-[3rem]` → `p-6/md:p-10/rounded-2xl`                                            
  - **Logo:** `max-h-16/mb-8` → `max-h-10/mb-5`                                                                         
  - **Upload areas:** `h-28–32/rounded-[2rem]` → `h-20–24/rounded-xl`                                                   
  - **Success icon:** `w-32/h-32/64px` → `w-20/h-20/40px`                                                             
  - 10 files changed, no logic modifications                                                                            
                                                                                                                      
  ---                                                                                                                   
                                                                                                                      
  ## How to test

  1. Run `make dev` and seed admin (`bun --env-file=../../.env scripts/seed-admin.ts`)                                  
  2. Log in at `http://localhost:5180`, create/open a form
  3. Visit the public form at `/f/<slug>`                                                                               
  4. Walk through all step types (Welcome → Rating → Core → Custom → Identity → Success)                              
  5. Verify compact layout, all interactions still work, no visual breaks on mobile                                     
                                                                                                                        
  ---                                                                                                                   
                                                                                                                        
  ## Checklist                                                                                                        

  - [x] My code follows the project conventions
  - [x] I tested this locally
  - [ ] I updated the documentation if needed                                                                           
  - [x] No console.log or debug code left
  - [x] No `.env` or secrets committed 