### PR TITLE
Feat/gdpr consent

### DIFF
--- a/.changeset/gdpr-consent-types.md
+++ b/.changeset/gdpr-consent-types.md
@@ -1,0 +1,5 @@
+---
+"@reviewskits/types": minor
+---
+
+Added GDPR consent flags (`consentPublic`, `consentInternal`, `consentedAt`) to `Testimonial` and `RawReview` interfaces.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 dev:
 	@echo "Starting infrastructure..."
-	docker compose -f infra/docker-compose.dev.yml up -d
+	docker compose --env-file .env -f infra/docker-compose.dev.yml up -d
 	@echo "Waiting for database to be ready..."
 	@until docker compose -f infra/docker-compose.dev.yml exec db pg_isready -U postgres > /dev/null 2>&1; do sleep 1; done
 	@echo "Pushing database schema..."

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ dev:
 	@until docker compose -f infra/docker-compose.dev.yml exec db pg_isready -U postgres > /dev/null 2>&1; do sleep 1; done
 	@echo "Pushing database schema..."
 	cd apps/server && bun run db:push
+	cd apps/server && bun run db:seed:admin
 	@echo "Starting dev server..."
 	bun run dev
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Reviewskits is built on a modern, fully type-safe stack — no legacy, no bloat:
 | Frontend (Admin) | [React](https://reactjs.org/) + [TailwindCSS](https://tailwindcss.com/) + [shadcn/ui](https://ui.shadcn.com/) |
 | Database | [PostgreSQL](https://www.postgresql.org/) + [Drizzle ORM](https://orm.drizzle.team/) |
 | Auth | [Better-Auth](https://better-auth.com/) |
-| Infra | [Docker](https://www.docker.com/) + Redis + Minio |
+| Infra | [Docker](https://www.docker.com/) + [Redis](https://redis.io/) + [Minio](https://www.min.io/) |
 | Docs | [VitePress](https://vitepress.dev/) |
 
 ---

--- a/apps/admin/src/components/dashboard/detail-view.tsx
+++ b/apps/admin/src/components/dashboard/detail-view.tsx
@@ -19,7 +19,9 @@ import {
   ArrowDown,
   GripVertical,
   Download,
-  Upload
+  Upload,
+  Globe,
+  Lock
 } from 'lucide-react'
 import {
   DndContext,
@@ -122,6 +124,23 @@ const SortableTestimonialRow = ({
           <span className="text-[10px] font-black text-(--v3-text) mt-1">{testimonial.rating}/5</span>
         </div>
       </td>
+      <td className="px-6 py-4 text-center">
+        <div className="flex items-center justify-center gap-1.5">
+          {testimonial.consentPublic && (
+            <div className="w-5 h-5 rounded bg-blue-500/10 text-blue-400 flex items-center justify-center" title="Public Consent">
+              <Globe size={11} strokeWidth={3} />
+            </div>
+          )}
+          {testimonial.consentInternal && (
+            <div className="w-5 h-5 rounded bg-purple-500/10 text-purple-400 flex items-center justify-center" title="Internal Consent">
+              <Lock size={11} strokeWidth={3} />
+            </div>
+          )}
+          {!testimonial.consentPublic && !testimonial.consentInternal && (
+            <span className="text-[10px] text-(--v3-muted2) italic">None</span>
+          )}
+        </div>
+      </td>
       <td className="px-6 py-4 text-center"><Badge status={testimonial.status} /></td>
       <td className="px-6 py-4 text-right">
         <div className="flex flex-col items-end">
@@ -148,11 +167,12 @@ export const DetailView = ({ form, onBack }: DetailViewProps) => {
   const [showSharePopover, setShowSharePopover] = useState(false)
   const [copiedLink, setCopiedLink] = useState(false)
   const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false)
+  const [publicOnly, setPublicOnly] = useState(false)
 
   // ── Data queries ───────────────────────────────────────────────────────────
   const { data: stats, isLoading: statsLoading } = useFormStats(form.id)
   const { data: testimonials = [], isLoading: testimonialsLoading } = useFormTestimonials(
-    form.id, page, sortConfig.field, sortConfig.order
+    form.id, page, sortConfig.field, sortConfig.order, publicOnly ? true : undefined
   )
 
   // ── Mutations ──────────────────────────────────────────────────────────────
@@ -191,14 +211,14 @@ export const DetailView = ({ form, onBack }: DetailViewProps) => {
     const reordered = arrayMove(testimonials, oldIndex, newIndex)
 
     // Optimistic update
-    qc.setQueryData(formTestimonialsKey(form.id, page, sortConfig.field, sortConfig.order), reordered)
+    qc.setQueryData(formTestimonialsKey(form.id, page, sortConfig.field, sortConfig.order, publicOnly ? true : undefined), reordered)
     // Persist
     reorderMutation.mutate(reordered.map((t, i) => ({ id: t.id, position: i + (page - 1) * 10 })))
   }
 
   const handleImported = () => {
     qc.invalidateQueries({ queryKey: formStatsKey(form.id) })
-    qc.invalidateQueries({ queryKey: formTestimonialsKey(form.id, page, sortConfig.field, sortConfig.order) })
+    qc.invalidateQueries({ queryKey: formTestimonialsKey(form.id, page, sortConfig.field, sortConfig.order, publicOnly ? true : undefined) })
   }
 
   // ── Derived values ─────────────────────────────────────────────────────────
@@ -375,6 +395,13 @@ export const DetailView = ({ form, onBack }: DetailViewProps) => {
               <Upload size={12} /> Import
             </button>
             <div className="w-px h-4 bg-white/10 mx-1" />
+            <div className="flex items-center gap-2 mr-2">
+              <Checkbox checked={publicOnly} onChange={setPublicOnly} />
+              <span className="text-[10px] font-black uppercase tracking-widest text-(--v3-text) opacity-80 cursor-pointer" onClick={() => setPublicOnly(!publicOnly)}>
+                Public Only
+              </span>
+            </div>
+            <div className="w-px h-4 bg-white/10" />
             <span className="text-[11px] font-bold text-(--v3-muted2)">{totReviews} total</span>
           </div>
         </div>
@@ -397,15 +424,16 @@ export const DetailView = ({ form, onBack }: DetailViewProps) => {
                     <th className="px-6 py-4 text-[10px] font-black uppercase tracking-widest text-(--v3-muted2) cursor-pointer hover:text-(--v3-teal) transition-colors" onClick={() => handleSort('authorName')}><div className="flex items-center">Author <SortIcon field="authorName" sortConfig={sortConfig} /></div></th>
                     <th className="px-6 py-4 text-[10px] font-black uppercase tracking-widest text-(--v3-muted2)">Review</th>
                     <th className="px-6 py-4 text-[10px] font-black uppercase tracking-widest text-(--v3-muted2) text-center cursor-pointer hover:text-(--v3-teal) transition-colors" onClick={() => handleSort('rating')}><div className="flex items-center justify-center">Rating <SortIcon field="rating" sortConfig={sortConfig} /></div></th>
+                    <th className="px-6 py-4 text-[10px] font-black uppercase tracking-widest text-(--v3-muted2) text-center">Consent</th>
                     <th className="px-6 py-4 text-[10px] font-black uppercase tracking-widest text-(--v3-muted2) text-center cursor-pointer hover:text-(--v3-teal) transition-colors" onClick={() => handleSort('status')}><div className="flex items-center justify-center">Status <SortIcon field="status" sortConfig={sortConfig} /></div></th>
                     <th className="px-6 py-4 text-[10px] font-black uppercase tracking-widest text-(--v3-muted2) text-right cursor-pointer hover:text-(--v3-teal) transition-colors" onClick={() => handleSort('createdAt')}><div className="flex items-center justify-end">Date <SortIcon field="createdAt" sortConfig={sortConfig} /></div></th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-(--v3-border)">
                   {testimonialsLoading ? (
-                    <tr><td colSpan={6} className="py-16 text-center"><RefreshCw size={20} className="animate-spin text-(--v3-teal) mx-auto" /></td></tr>
+                    <tr><td colSpan={7} className="py-16 text-center"><RefreshCw size={20} className="animate-spin text-(--v3-teal) mx-auto" /></td></tr>
                   ) : testimonials.length === 0 ? (
-                    <tr><td colSpan={6} className="py-16 text-center text-(--v3-muted2) italic text-sm">No reviews found.</td></tr>
+                    <tr><td colSpan={7} className="py-16 text-center text-(--v3-muted2) italic text-sm">No reviews found.</td></tr>
                   ) : testimonials.map((r) => (
                     <SortableTestimonialRow
                       key={r.id}

--- a/apps/admin/src/components/form-editor/EditorCanvas.tsx
+++ b/apps/admin/src/components/form-editor/EditorCanvas.tsx
@@ -14,7 +14,7 @@ interface EditorCanvasProps {
   onScrollToStep: (stepId: string) => void
   onMoveStep: (index: number, direction: 'up' | 'down') => void
   onDeleteStep: (stepId: string) => void
-  onAddStep: () => void
+  onAddStep: (insertAfterIndex?: number) => void
 }
 
 function stepTypeBadge(step: FormStep, index: number) {
@@ -134,20 +134,17 @@ export function EditorCanvas({
               </div>
             )}
 
-            {/* Add step button — appears before identity/attribution */}
-            {(form.config.steps[index + 1]?.type === 'identity' ||
-              form.config.steps[index + 1]?.type === 'attribution') && (
-              <div className="flex items-center justify-center py-2 w-full">
-                <button className="flex flex-col items-center gap-4 group" onClick={onAddStep}>
-                  <div className="w-16 h-16 rounded-full bg-white/5 border border-dashed border-white/20 flex items-center justify-center group-hover:bg-[#0D9E75]/10 group-hover:border-[#0D9E75] transition-all">
-                    <Plus size={24} className="text-white/40 group-hover:text-[#0D9E75]" />
-                  </div>
-                  <span className="text-[10px] font-black uppercase tracking-widest text-white/20 group-hover:text-white/60">
-                    Add a step
-                  </span>
-                </button>
-              </div>
-            )}
+            {/* Add step button — appears after all steps */}
+            <div className="flex items-center justify-center py-2 w-full mb-6">
+              <button type="button" className="flex flex-col items-center gap-4 group" onClick={(e) => { e.preventDefault(); onAddStep(index); }}>
+                <div className="w-16 h-16 rounded-full bg-white/5 border border-dashed border-white/20 flex items-center justify-center group-hover:bg-[#0D9E75]/10 group-hover:border-[#0D9E75] transition-all">
+                  <Plus size={24} className="text-white/40 group-hover:text-[#0D9E75]" />
+                </div>
+                <span className="text-[10px] font-black uppercase tracking-widest text-white/20 group-hover:text-white/60">
+                  Add a step
+                </span>
+              </button>
+            </div>
           </div>
         ))}
       </div>

--- a/apps/admin/src/components/form-editor/EditorCanvas.tsx
+++ b/apps/admin/src/components/form-editor/EditorCanvas.tsx
@@ -52,8 +52,8 @@ export function EditorCanvas({
     >
       <style>{`section::-webkit-scrollbar { display: none; }`}</style>
 
-      {/* Sticky reorder/delete controls — hidden for locked steps */}
-      {!activeStep?.locked && (
+      {/* Sticky reorder/delete controls — hidden for locked steps or consent step */}
+      {(!activeStep?.locked && activeStep?.type !== 'consent') && (
         <div className="sticky top-0 right-0 z-50 flex justify-end p-0 pointer-events-none">
           <div className="flex gap-1 bg-[#0A0A0A]/60 backdrop-blur-md p-1 rounded-bl-xl border-l border-b border-white/10 pointer-events-auto shadow-2xl overflow-hidden">
             <button

--- a/apps/admin/src/components/form-editor/EditorSidebarStepTab.tsx
+++ b/apps/admin/src/components/form-editor/EditorSidebarStepTab.tsx
@@ -155,6 +155,36 @@ export function EditorSidebarStepTab({
               </div>
             )}
 
+            {/* Consent labels (consent) */}
+            {activeStep.type === 'consent' && (
+              <div className="space-y-4">
+                <div>
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-(--v3-muted2) mb-3 block">
+                    Public Consent Text
+                  </label>
+                  <textarea
+                    ref={setSidebarRef('publicLabel')}
+                    value={(cfg?.publicLabel as string) || ''}
+                    onChange={(e) => onUpdateStep(activeStep.id, { config: { ...activeStep.config, publicLabel: e.target.value } })}
+                    placeholder="I agree that my testimonial may be displayed..."
+                    className="w-full bg-(--v3-bg) border border-(--v3-border) rounded-xl px-4 py-3 text-sm focus:border-(--v3-teal)/50 transition-all outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-(--v3-muted2) mb-3 block">
+                    Internal Consent Text
+                  </label>
+                  <textarea
+                    ref={setSidebarRef('internalLabel')}
+                    value={(cfg?.internalLabel as string) || ''}
+                    onChange={(e) => onUpdateStep(activeStep.id, { config: { ...activeStep.config, internalLabel: e.target.value } })}
+                    placeholder="I agree that my data may be used internally..."
+                    className="w-full bg-(--v3-bg) border border-(--v3-border) rounded-xl px-4 py-3 text-sm focus:border-(--v3-teal)/50 transition-all outline-none"
+                  />
+                </div>
+              </div>
+            )}
+
             {/* Custom fields */}
             {activeStep.type === 'custom' && (
               <div className="space-y-4">
@@ -250,7 +280,7 @@ export function EditorSidebarStepTab({
                 <div className={`absolute top-1 w-3 h-3 bg-white rounded-full transition-all ${activeStep.isEnabled ? 'left-6' : 'left-1'}`} />
               </button>
             </div>
-            {!activeStep.locked && (
+            {(!activeStep.locked && activeStep.type !== 'consent') && (
               <button
                 onClick={() => onDeleteStep(activeStep.id)}
                 className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-[10px] font-black uppercase tracking-wider text-red-400/60 hover:text-red-400 hover:bg-red-500/10 border border-transparent hover:border-red-500/20 transition-all"

--- a/apps/admin/src/components/form-editor/StepPreview.tsx
+++ b/apps/admin/src/components/form-editor/StepPreview.tsx
@@ -291,6 +291,35 @@ export function StepPreview({
         </div>
       )}
 
+      {/* Consent */}
+      {step.type === 'consent' && (
+        <div className="w-full max-w-md flex flex-col items-center gap-y-6 text-center">
+          <EditableTitle {...sharedProps} headingFont={headingFont} />
+          <EditableDescription {...sharedProps} />
+          <div className="w-full space-y-4 text-left border border-transparent">
+            <label className="flex items-start gap-4 p-4 rounded-xl border border-gray-100 bg-gray-50">
+              <input type="checkbox" disabled checked className="mt-1" />
+              <span 
+                className={`text-xs text-gray-800 leading-snug ${editableCls(selectedElement === 'publicLabel' && activeStepId === step.id)}`}
+                onClick={() => onElementClick('publicLabel', step.id)}
+              >
+                {(cfg?.publicLabel as string) || 'I agree that my testimonial may be displayed publicly for marketing purposes.'}
+              </span>
+            </label>
+            <label className="flex items-start gap-4 p-4 rounded-xl border border-gray-100 bg-gray-50">
+              <input type="checkbox" disabled checked className="mt-1" />
+              <span 
+                className={`text-xs text-gray-800 leading-snug ${editableCls(selectedElement === 'internalLabel' && activeStepId === step.id)}`}
+                onClick={() => onElementClick('internalLabel', step.id)}
+              >
+                {(cfg?.internalLabel as string) || 'I agree that my data may be used internally for product improvement.'}
+              </span>
+            </label>
+          </div>
+          <EditableButton {...sharedProps} primaryColor={primaryColor} bodyFont={bodyFont} defaultLabel="Submit" />
+        </div>
+      )}
+
       {/* Custom */}
       {step.type === 'custom' && (
         <div className="w-full max-w-md flex flex-col items-center gap-y-6 text-center">

--- a/apps/admin/src/components/form-editor/types.ts
+++ b/apps/admin/src/components/form-editor/types.ts
@@ -9,7 +9,7 @@ export interface StepField {
 
 export interface FormStep {
   id: string
-  type: 'welcome' | 'core' | 'identity' | 'success' | 'custom' | 'rating' | 'textarea' | 'attribution' | 'informative'
+  type: 'welcome' | 'core' | 'identity' | 'success' | 'custom' | 'rating' | 'textarea' | 'attribution' | 'informative' | 'consent'
   title: string
   description?: string
   isEnabled: boolean

--- a/apps/admin/src/hooks/useFormDetail.ts
+++ b/apps/admin/src/hooks/useFormDetail.ts
@@ -7,8 +7,8 @@ import { normalizeStepOrder } from '../components/form-editor/utils'
 
 export const formDetailKey = (id: string) => ['form', id] as const
 export const formStatsKey = (id: string) => ['form', id, 'stats'] as const
-export const formTestimonialsKey = (id: string, page: number, sort: string | null, order: string) =>
-  ['form', id, 'testimonials', page, sort, order] as const
+export const formTestimonialsKey = (id: string, page: number, sort: string | null, order: string, consentPublic?: boolean) =>
+  ['form', id, 'testimonials', page, sort, order, consentPublic] as const
 
 /** For FormEditorPage — returns FullForm with steps normalized */
 export function useFormById(id: string | undefined) {
@@ -44,11 +44,12 @@ export function useFormTestimonials(
   formId: string,
   page: number,
   sort: string | null,
-  order: 'asc' | 'desc'
+  order: 'asc' | 'desc',
+  consentPublic?: boolean
 ) {
   return useQuery({
-    queryKey: formTestimonialsKey(formId, page, sort, order),
-    queryFn: () => testimonialsService.listByForm(formId, { page, sort, order }),
+    queryKey: formTestimonialsKey(formId, page, sort, order, consentPublic),
+    queryFn: () => testimonialsService.listByForm(formId, { page, sort, order, consentPublic }),
     enabled: !!formId,
   })
 }

--- a/apps/admin/src/pages/FormEditorPage.tsx
+++ b/apps/admin/src/pages/FormEditorPage.tsx
@@ -92,7 +92,7 @@ function FormEditorContent({ initialForm, formId }: { initialForm: FullForm; for
     })
   }, [])
 
-  const addStep = useCallback(() => {
+  const addStep = useCallback((insertAfterIndex?: number) => {
     setForm((prev) => {
       const newId = `step_${Date.now()}`
       const newStep: FormStep = {
@@ -107,12 +107,21 @@ function FormEditorContent({ initialForm, formId }: { initialForm: FullForm; for
           buttonText: 'Continue',
         },
       }
-      const insertAt = prev.config.steps.findIndex(
-        (s) => s.type === 'identity' || s.type === 'attribution'
-      )
-      const steps = insertAt >= 0
-        ? [...prev.config.steps.slice(0, insertAt), newStep, ...prev.config.steps.slice(insertAt)]
-        : [...prev.config.steps, newStep]
+
+      const steps = [...prev.config.steps]
+      if (insertAfterIndex !== undefined && insertAfterIndex >= 0 && insertAfterIndex < steps.length) {
+        steps.splice(insertAfterIndex + 1, 0, newStep)
+      } else {
+        const insertAt = steps.findIndex(
+          (s) => s.type === 'identity' || s.type === 'attribution' || s.type === 'success'
+        )
+        if (insertAt >= 0) {
+          steps.splice(insertAt, 0, newStep)
+        } else {
+          steps.push(newStep)
+        }
+      }
+
       setTimeout(() => scrollToStep(newId), 100)
       return { ...prev, config: { ...prev.config, steps } }
     })

--- a/apps/admin/src/pages/PublicFormPage.tsx
+++ b/apps/admin/src/pages/PublicFormPage.tsx
@@ -14,6 +14,7 @@ import { IdentityStep } from './public-form/steps/IdentityStep'
 import { CoreStep } from './public-form/steps/CoreStep'
 import { CustomStep } from './public-form/steps/CustomStep'
 import { SuccessStep } from './public-form/steps/SuccessStep'
+import { ConsentStep } from './public-form/steps/ConsentStep'
 
 export default function PublicFormPage() {
   const { slug } = useParams()
@@ -29,6 +30,8 @@ export default function PublicFormPage() {
   const [authorEmail, setAuthorEmail] = useState('')
   const [authorTitle, setAuthorTitle] = useState('')
   const [authorUrl, setAuthorUrl] = useState('')
+  const [consentPublic, setConsentPublic] = useState(false)
+  const [consentInternal, setConsentInternal] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   // Selection state for custom step fields (fieldId → selected value)
   const [customFieldValues, setCustomFieldValues] = useState<Record<string, unknown>>({})
@@ -125,8 +128,18 @@ export default function PublicFormPage() {
   const appliedBodyFont = fontsReady ? bodyFont : 'system-ui, sans-serif'
 
   const handleNext = async () => {
-    if (currentStep?.type === 'identity' || currentStep?.type === 'attribution') {
-      await handleSubmit()
+    if (currentStep?.type === 'consent' || currentStep?.type === 'identity' || currentStep?.type === 'attribution') {
+      // If there is a consent step, the submit action happens on the consent step.
+      // But identity/attribution can also be the last step (submitting) if no consent step is placed after them (backward compatibility). 
+      // Based on the new design, Consent is the final step. Wait, the problem is identity/attribution have a submit action.
+      // Let's check if it is the last step (or if a consent step follows).
+      const isLastPreSubmitStep = !steps.slice(currentStepIndex + 1).some(s => s.type === 'consent' || s.type === 'identity' || s.type === 'attribution');
+      
+      if (currentStep?.type === 'consent' || isLastPreSubmitStep) {
+        await handleSubmit()
+      } else {
+        setCurrentStepIndex(prev => prev + 1)
+      }
     } else {
       setCurrentStepIndex(prev => prev + 1)
     }
@@ -170,6 +183,8 @@ export default function PublicFormPage() {
           authorTitle,
           authorUrl,
           rating,
+          consentPublic,
+          consentInternal,
           metadata: Object.keys(metadata).length > 0 ? metadata : undefined
         })
       })
@@ -284,6 +299,21 @@ export default function PublicFormPage() {
               setAuthorTitle={setAuthorTitle} 
               authorUrl={authorUrl} 
               setAuthorUrl={setAuthorUrl} 
+              submitting={submitting && (currentStepIndex === steps.length - 1 || steps[currentStepIndex + 1]?.type === 'success')} 
+              onNext={handleNext} 
+              onBack={() => setCurrentStepIndex(prev => prev - 1)} 
+            />
+          )}
+
+          {currentStep?.type === 'consent' && (
+            <ConsentStep 
+              step={currentStep} 
+              primaryColor={primaryColor} 
+              appliedHeadingFont={appliedHeadingFont} 
+              consentPublic={consentPublic} 
+              setConsentPublic={setConsentPublic}
+              consentInternal={consentInternal}
+              setConsentInternal={setConsentInternal}
               submitting={submitting} 
               onNext={handleNext} 
               onBack={() => setCurrentStepIndex(prev => prev - 1)} 
@@ -316,7 +346,7 @@ export default function PublicFormPage() {
               setAuthorTitle={setAuthorTitle} 
               authorUrl={authorUrl} 
               setAuthorUrl={setAuthorUrl} 
-              submitting={submitting} 
+              submitting={submitting && (currentStepIndex === steps.length - 1 || steps[currentStepIndex + 1]?.type === 'success')} 
               onNext={handleNext} 
               onBack={() => setCurrentStepIndex(prev => prev - 1)} 
             />

--- a/apps/admin/src/pages/public-form/steps/ConsentStep.tsx
+++ b/apps/admin/src/pages/public-form/steps/ConsentStep.tsx
@@ -1,0 +1,84 @@
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import type { FormStep } from '../types'
+
+interface ConsentStepProps {
+  step: FormStep
+  primaryColor: string
+  appliedHeadingFont: string
+  consentPublic: boolean
+  consentInternal: boolean
+  setConsentPublic: (val: boolean) => void
+  setConsentInternal: (val: boolean) => void
+  submitting: boolean
+  onNext: () => void
+  onBack: () => void
+}
+
+export function ConsentStep({ 
+  step, 
+  primaryColor, 
+  appliedHeadingFont, 
+  consentPublic,
+  consentInternal,
+  setConsentPublic,
+  setConsentInternal,
+  submitting,
+  onNext, 
+  onBack 
+}: ConsentStepProps) {
+  const publicLabel = (step.config as Record<string, string>)?.publicLabel || 'I agree that my testimonial may be displayed publicly for marketing purposes.'
+  const internalLabel = (step.config as Record<string, string>)?.internalLabel || 'I agree that my data may be used internally for product improvement.'
+  
+  const isValid = consentPublic || consentInternal
+
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-8 duration-700 w-full flex flex-col items-center">
+      <h1 className="text-4xl font-black tracking-tighter text-black mb-6" style={{ fontFamily: appliedHeadingFont, color: '#000000' }}>
+        {step.title || 'Data Consent'}
+      </h1>
+      <p className="text-gray-600 mb-10 text-xl leading-relaxed">
+        {step.description || 'Please let us know how we can use your feedback.'}
+      </p>
+
+      <div className="w-full space-y-6 mb-10 text-left">
+        <label className="flex items-start gap-4 p-5 rounded-2xl border-2 border-gray-100 bg-gray-50 hover:bg-gray-100 cursor-pointer transition-colors">
+          <input 
+            type="checkbox" 
+            checked={consentPublic} 
+            onChange={(e) => setConsentPublic(e.target.checked)} 
+            className="mt-1 w-6 h-6 text-black rounded border-gray-300 focus:ring-black"
+            style={{ accentColor: primaryColor }}
+          />
+          <span className="text-lg text-gray-800 leading-snug">{publicLabel}</span>
+        </label>
+
+        <label className="flex items-start gap-4 p-5 rounded-2xl border-2 border-gray-100 bg-gray-50 hover:bg-gray-100 cursor-pointer transition-colors">
+          <input 
+            type="checkbox" 
+            checked={consentInternal} 
+            onChange={(e) => setConsentInternal(e.target.checked)} 
+            className="mt-1 w-6 h-6 text-black rounded border-gray-300 focus:ring-black"
+            style={{ accentColor: primaryColor }}
+          />
+          <span className="text-lg text-gray-800 leading-snug">{internalLabel}</span>
+        </label>
+      </div>
+
+      <div className="flex gap-4 w-full">
+        <button onClick={onBack}
+          className="px-6 py-5 rounded-2xl bg-gray-100 text-gray-600 hover:bg-gray-200 transition-all font-bold"
+        >
+          <ArrowLeft size={22} />
+        </button>
+        <button
+          disabled={!isValid || submitting}
+          onClick={onNext}
+          style={{ backgroundColor: isValid ? primaryColor : '#E5E7EB' }}
+          className="flex-1 py-5 rounded-2xl text-white font-bold text-lg shadow-lg hover:scale-[1.02] active:scale-[0.98] transition-all disabled:opacity-50 flex items-center justify-center gap-3"
+        >
+          {submitting ? <Loader2 size={28} className="animate-spin" /> : ((step.config as Record<string, string>)?.buttonText || 'Submit')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/admin/src/pages/public-form/types.ts
+++ b/apps/admin/src/pages/public-form/types.ts
@@ -9,7 +9,7 @@ export interface StepField {
 
 export interface FormStep {
   id: string
-  type: 'welcome' | 'core' | 'identity' | 'success' | 'custom' | 'rating' | 'textarea' | 'attribution' | 'informative'
+  type: 'welcome' | 'core' | 'identity' | 'success' | 'custom' | 'rating' | 'textarea' | 'attribution' | 'informative' | 'consent'
   title: string
   description?: string
   isEnabled: boolean

--- a/apps/admin/src/services/testimonials.service.ts
+++ b/apps/admin/src/services/testimonials.service.ts
@@ -34,6 +34,8 @@ export interface TestimonialListItem {
   createdAt: string
   status: string
   authorEmail?: string
+  consentPublic?: boolean
+  consentInternal?: boolean
 }
 
 export interface FormStats {
@@ -92,10 +94,11 @@ export const testimonialsService = {
 
   listByForm: (
     formId: string,
-    params: { page?: number; sort?: string | null; order?: 'asc' | 'desc' }
+    params: { page?: number; sort?: string | null; order?: 'asc' | 'desc'; consentPublic?: boolean }
   ): Promise<TestimonialListItem[]> => {
     const qs = new URLSearchParams({ page: String(params.page ?? 1) })
     if (params.sort) { qs.set('sort', params.sort); qs.set('order', params.order ?? 'desc') }
+    if (params.consentPublic !== undefined) { qs.set('consentPublic', String(params.consentPublic)) }
     return fetch(`/api/v1/forms/${formId}/testimonials?${qs}`).then(handleResponse<TestimonialListItem[]>)
   },
 

--- a/apps/server/src/application/use-cases/forms/CreateFormUseCase.ts
+++ b/apps/server/src/application/use-cases/forms/CreateFormUseCase.ts
@@ -37,7 +37,20 @@ const buildDefaultSteps = (): FormStep[] => [
     description: 'This information will be displayed with your testimonial.',
     isEnabled: true,
     locked: true,
-    config: { collectEmail: true, collectCompany: false, collectSocialLinks: false, buttonText: 'Submit' }
+    config: { collectEmail: true, collectCompany: false, collectSocialLinks: false, buttonText: 'Continue' }
+  },
+  {
+    id: randomUUID(),
+    type: 'consent',
+    title: 'Data Consent',
+    description: 'Please let us know how we can use your feedback.',
+    isEnabled: true,
+    locked: true,
+    config: { 
+      publicLabel: 'I agree that my testimonial may be displayed publicly for marketing purposes.',
+      internalLabel: 'I agree that my data may be used internally for product improvement.',
+      buttonText: 'Submit' 
+    }
   },
   {
     id: randomUUID(),

--- a/apps/server/src/application/use-cases/forms/GetFormTestimonialsUseCase.ts
+++ b/apps/server/src/application/use-cases/forms/GetFormTestimonialsUseCase.ts
@@ -9,6 +9,7 @@ export interface GetFormTestimonialsRequest {
   limit: number;
   sort?: string;
   order?: 'asc' | 'desc';
+  consentPublic?: boolean;
 }
 
 export class GetFormTestimonialsUseCase {
@@ -30,7 +31,8 @@ export class GetFormTestimonialsUseCase {
       limit, 
       offset, 
       sort, 
-      order 
+      order,
+      consentPublic: request.consentPublic
     });
 
     return testimonials.map(t => {

--- a/apps/server/src/application/use-cases/public-reviews/SubmitReviewUseCase.ts
+++ b/apps/server/src/application/use-cases/public-reviews/SubmitReviewUseCase.ts
@@ -19,6 +19,8 @@ export interface SubmitReviewRequest {
   authorTitle?: string;
   authorUrl?: string;
   metadata?: Record<string, unknown>;
+  consentPublic: boolean;
+  consentInternal: boolean;
 }
 
 export class SubmitReviewUseCase {
@@ -32,7 +34,7 @@ export class SubmitReviewUseCase {
   ) {}
 
   async execute(request: SubmitReviewRequest): Promise<string> {
-    const { formId, content, authorName, authorEmail, rating, authorTitle, authorUrl, metadata } = request;
+    const { formId, content, authorName, authorEmail, rating, authorTitle, authorUrl, metadata, consentPublic, consentInternal } = request;
 
     const form = await this.formRepository.findByPublicId(formId);
     if (!form) {
@@ -51,6 +53,9 @@ export class SubmitReviewUseCase {
       authorUrl: (authorUrl && authorUrl !== '') ? authorUrl : undefined,
       status: 'pending',
       source: 'form',
+      consentPublic,
+      consentInternal,
+      consentedAt: (consentPublic || consentInternal) ? new Date() : undefined,
       metadata: metadata && Object.keys(metadata).length > 0 ? metadata : undefined
     });
 

--- a/apps/server/src/domain/entities/Form.ts
+++ b/apps/server/src/domain/entities/Form.ts
@@ -3,7 +3,7 @@ import { deepMerge } from "../../shared/utils/deepMerge";
 
 export interface FormStep {
   id: string;
-  type: 'welcome' | 'core' | 'identity' | 'success' | 'custom' | 'rating' | 'textarea' | 'attribution' | 'informative';
+  type: 'welcome' | 'core' | 'identity' | 'success' | 'custom' | 'rating' | 'textarea' | 'attribution' | 'informative' | 'consent';
   title: string;
   description?: string;
   isEnabled: boolean;

--- a/apps/server/src/domain/entities/Testimonial.ts
+++ b/apps/server/src/domain/entities/Testimonial.ts
@@ -16,6 +16,9 @@ export interface TestimonialProps {
   formId?: string;
   mediaId?: string;
   position?: number;
+  consentPublic?: boolean;
+  consentInternal?: boolean;
+  consentedAt?: Date;
   createdAt?: Date;
   updatedAt?: Date;
   metadata?: Record<string, any>;
@@ -35,6 +38,9 @@ export class Testimonial {
   private formId?: string;
   private mediaId?: string;
   private position: number;
+  private consentPublic: boolean;
+  private consentInternal: boolean;
+  private consentedAt?: Date;
   public readonly createdAt: Date;
   private updatedAt: Date;
   private metadata: Record<string, any>;
@@ -62,6 +68,9 @@ export class Testimonial {
     this.formId = props.formId;
     this.mediaId = props.mediaId;
     this.position = props.position ?? 0;
+    this.consentPublic = props.consentPublic ?? false;
+    this.consentInternal = props.consentInternal ?? false;
+    this.consentedAt = props.consentedAt;
     this.createdAt = props.createdAt ?? new Date();
     this.updatedAt = props.updatedAt ?? new Date();
     this.metadata = props.metadata ?? {};
@@ -82,6 +91,9 @@ export class Testimonial {
       formId: this.formId,
       mediaId: this.mediaId,
       position: this.position,
+      consentPublic: this.consentPublic,
+      consentInternal: this.consentInternal,
+      consentedAt: this.consentedAt,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
       metadata: this.metadata,

--- a/apps/server/src/domain/repositories/ITestimonialRepository.ts
+++ b/apps/server/src/domain/repositories/ITestimonialRepository.ts
@@ -12,7 +12,7 @@ export interface ITestimonialRepository {
   batchSave(testimonials: Testimonial[]): Promise<void>;
   update(testimonial: Testimonial): Promise<void>;
   findApprovedByUser(userId: string, options: { limit?: number; minRating?: number; formId: string }): Promise<Testimonial[]>;
-  findByFormId(formId: string, options?: { limit?: number; offset?: number; sort?: string; order?: 'asc' | 'desc' }): Promise<Testimonial[]>;
+  findByFormId(formId: string, options?: { limit?: number; offset?: number; sort?: string; order?: 'asc' | 'desc'; consentPublic?: boolean }): Promise<Testimonial[]>;
   batchUpdateStatus(ids: string[], status: 'approved' | 'rejected' | 'pending'): Promise<void>;
   updatePositions(positions: { id: string; position: number }[]): Promise<void>;
   getStatsByUser(userId: string): Promise<{

--- a/apps/server/src/infrastructure/database/schema.ts
+++ b/apps/server/src/infrastructure/database/schema.ts
@@ -140,6 +140,9 @@ export const testimonials = pgTable('testimonials', {
   mediaId: uuid('media_id').references(() => media.id, { onDelete: 'set null' }),
   position: integer('position').notNull().default(0),
   metadata: jsonb('metadata').default({}),
+  consentPublic: boolean('consent_public').notNull().default(false),
+  consentInternal: boolean('consent_internal').notNull().default(false),
+  consentedAt: timestamp('consented_at'),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 }, (t) => ({

--- a/apps/server/src/infrastructure/repositories/DrizzleTestimonialRepository.ts
+++ b/apps/server/src/infrastructure/repositories/DrizzleTestimonialRepository.ts
@@ -58,6 +58,9 @@ export class DrizzleTestimonialRepository implements ITestimonialRepository {
       authorUrl: props.authorUrl,
       mediaId: props.mediaId,
       position: props.position,
+      consentPublic: props.consentPublic,
+      consentInternal: props.consentInternal,
+      consentedAt: props.consentedAt,
       metadata: props.metadata ?? {},
       createdAt: props.createdAt,
       updatedAt: props.updatedAt,
@@ -83,6 +86,9 @@ export class DrizzleTestimonialRepository implements ITestimonialRepository {
         authorUrl: props.authorUrl,
         mediaId: props.mediaId,
         position: props.position,
+        consentPublic: props.consentPublic,
+        consentInternal: props.consentInternal,
+        consentedAt: props.consentedAt,
         metadata: props.metadata ?? {},
         createdAt: props.createdAt,
         updatedAt: props.updatedAt,
@@ -105,6 +111,9 @@ export class DrizzleTestimonialRepository implements ITestimonialRepository {
         authorUrl: props.authorUrl,
         mediaId: props.mediaId,
         position: props.position,
+        consentPublic: props.consentPublic,
+        consentInternal: props.consentInternal,
+        consentedAt: props.consentedAt,
         metadata: props.metadata ?? {},
         updatedAt: props.updatedAt,
       })
@@ -116,7 +125,8 @@ export class DrizzleTestimonialRepository implements ITestimonialRepository {
     const { gte } = await import('drizzle-orm');
     const whereConditions = [
       eq(testimonials.userId, userId),
-      eq(testimonials.status, 'approved')
+      eq(testimonials.status, 'approved'),
+      eq(testimonials.consentPublic, true)
     ];
 
     if (options?.minRating) {
@@ -140,12 +150,19 @@ export class DrizzleTestimonialRepository implements ITestimonialRepository {
     return rows.map(row => this.mapToDomain(row));
   }
 
-  async findByFormId(formId: string, options?: { limit?: number; offset?: number; sort?: string; order?: 'asc' | 'desc' }): Promise<Testimonial[]> {
-    const { asc, desc } = await import('drizzle-orm');
+  async findByFormId(formId: string, options?: { limit?: number; offset?: number; sort?: string; order?: 'asc' | 'desc'; consentPublic?: boolean }): Promise<Testimonial[]> {
+    const { asc, desc, and } = await import('drizzle-orm');
     
+    let whereClause;
+    if (options?.consentPublic !== undefined) {
+      whereClause = and(eq(testimonials.formId, formId), eq(testimonials.consentPublic, options.consentPublic));
+    } else {
+      whereClause = eq(testimonials.formId, formId);
+    }
+
     const query = this.db.select()
       .from(testimonials)
-      .where(eq(testimonials.formId, formId));
+      .where(whereClause);
 
     // Handle dynamic sorting
     const sortField = options?.sort;
@@ -487,6 +504,9 @@ export class DrizzleTestimonialRepository implements ITestimonialRepository {
       formId: row.formId || undefined,
       mediaId: row.mediaId || undefined,
       position: row.position || 0,
+      consentPublic: row.consentPublic || false,
+      consentInternal: row.consentInternal || false,
+      consentedAt: row.consentedAt || undefined,
       metadata: this.parseJsonb(row.metadata),
       createdAt: row.createdAt || undefined,
       updatedAt: row.updatedAt || undefined,

--- a/apps/server/src/interface/controllers/formController.ts
+++ b/apps/server/src/interface/controllers/formController.ts
@@ -204,6 +204,8 @@ export const formController = {
 
     const sort = c.req.query('sort') || 'createdAt';
     const order = (c.req.query('order') || 'desc') as 'asc' | 'desc';
+    const consentPublicParam = c.req.query('consentPublic');
+    const consentPublic = consentPublicParam ? consentPublicParam === 'true' : undefined;
 
     try {
       const testimonials = await container.getFormTestimonialsUseCase.execute({
@@ -212,7 +214,8 @@ export const formController = {
         page,
         limit,
         sort,
-        order
+        order,
+        consentPublic
       });
       return c.json(testimonials);
     } catch (err: any) {

--- a/apps/server/src/interface/controllers/publicReviewController.ts
+++ b/apps/server/src/interface/controllers/publicReviewController.ts
@@ -14,7 +14,12 @@ const submitReviewSchema = z.object({
     message: "Only http and https protocols are allowed for authorUrl"
   }).optional().or(z.literal('')),
   _honey: z.string().optional(),
-  metadata: z.record(z.string(), z.unknown()).optional()
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  consentPublic: z.boolean().optional().default(false),
+  consentInternal: z.boolean().optional().default(false),
+}).refine(data => data.consentPublic || data.consentInternal, {
+  message: "You must provide at least one form of consent.",
+  path: ["consentPublic"]
 });
 
 export const publicReviewController = {
@@ -63,7 +68,7 @@ export const publicReviewController = {
       return c.json({ error: validation.error.issues[0]?.message || 'Invalid input' }, 400);
     }
 
-    const { formId, content, authorName, authorEmail, rating, authorTitle, authorUrl, _honey, metadata } = validation.data;
+    const { formId, content, authorName, authorEmail, rating, authorTitle, authorUrl, _honey, metadata, consentPublic, consentInternal } = validation.data;
 
     // Honeypot check - Spambots usually fill hidden fields
     if (_honey) {
@@ -84,7 +89,9 @@ export const publicReviewController = {
         rating,
         authorTitle,
         authorUrl,
-        metadata
+        metadata,
+        consentPublic,
+        consentInternal
       });
 
       return c.json({ 

--- a/apps/server/tests/integration/controllers/publicReviewController.test.ts
+++ b/apps/server/tests/integration/controllers/publicReviewController.test.ts
@@ -36,7 +36,8 @@ describe("Public Review Controller Integration", () => {
       body: JSON.stringify({
         formId: publicFormId,
         content: "Great product!",
-        authorName: "Valid User"
+        authorName: "Valid User",
+        consentPublic: true
       }),
       headers: { "Content-Type": "application/json" }
     });
@@ -57,6 +58,7 @@ describe("Public Review Controller Integration", () => {
         formId: publicFormId,
         content: "Spam message",
         authorName: "Spammer",
+        consentPublic: true,
         _honey: "im_a_bot"
       }),
       headers: { "Content-Type": "application/json" }
@@ -75,7 +77,8 @@ describe("Public Review Controller Integration", () => {
     const body = JSON.stringify({
       formId: publicFormId,
       content: "Nice!",
-      authorName: "Fast User"
+      authorName: "Fast User",
+      consentPublic: true
     });
 
     // We allow 5 requests. Send 5

--- a/apps/server/tests/integration/security/SecurityChecks.test.ts
+++ b/apps/server/tests/integration/security/SecurityChecks.test.ts
@@ -32,7 +32,8 @@ describe("Security Checks Integration", () => {
       body: JSON.stringify({
         formId: publicFormId,
         content: longContent,
-        authorName: "Attacker"
+        authorName: "Attacker",
+        consentPublic: true
       }),
       headers: { "Content-Type": "application/json" }
     });
@@ -57,6 +58,7 @@ describe("Security Checks Integration", () => {
           formId: publicFormId,
           content: "Nice!",
           authorName: "Attacker",
+          consentPublic: true,
           authorUrl
         }),
         headers: { "Content-Type": "application/json" }
@@ -87,6 +89,7 @@ describe("Security Checks Integration", () => {
           formId: publicFormId,
           content: "Valid review",
           authorName: "Good User",
+          consentPublic: true,
           authorUrl
         }),
         headers: { "Content-Type": "application/json" }
@@ -104,7 +107,8 @@ describe("Security Checks Integration", () => {
             body: JSON.stringify({
                 formId: publicFormId,
                 content: `Review ${i}`,
-                authorName: "Good User"
+                authorName: "Good User",
+                consentPublic: true
             }),
             headers: { "Content-Type": "application/json" }
         });
@@ -117,7 +121,8 @@ describe("Security Checks Integration", () => {
         body: JSON.stringify({
             formId: publicFormId,
             content: "One too many",
-            authorName: "Spammer"
+            authorName: "Spammer",
+            consentPublic: true
         }),
         headers: { "Content-Type": "application/json" }
     });

--- a/infra/docker-compose.coolify.yml
+++ b/infra/docker-compose.coolify.yml
@@ -1,7 +1,7 @@
 # ┌─────────────────────────────────────────────────────────────────┐
-# │  PaaS Coolify — SSL et réseau gérés par Coolify                 │
-# │  Requis : instance Coolify configurée                           │
-# │  Usage  : coller ce fichier dans un Docker Compose Resource     │
+# │  PaaS Coolify — SSL and networking managed by Coolify           │
+# │  Requirement: Configured Coolify instance                       │
+# │  Usage  : Paste this file into a Docker Compose Resource        │
 # └─────────────────────────────────────────────────────────────────┘
 
 services:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,18 +1,16 @@
 # ┌─────────────────────────────────────────────────────────────────┐
-# │  Développement local — infrastructure uniquement                │
-# │  Lance : PostgreSQL, Redis, MinIO, Mailpit                      │
-# │  L'application (bun dev) tourne sur le host, pas dans Docker   │
-# │  Usage  : make dev  (ou docker compose -f infra/docker-compose.dev.yml up -d) │
+# │  Local Development — infrastructure only                        │
+# │  Starts: PostgreSQL, Redis, MinIO, Mailpit                       │
+# │  The application (bun dev) runs on the host, not in Docker      │
+# │  Usage  : make dev  (or docker compose -f infra/docker-compose.dev.yml up -d) │
 # └─────────────────────────────────────────────────────────────────┘
 
 services:
   db:
     image: postgres:16-alpine
     restart: unless-stopped
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      POSTGRES_DB: ${POSTGRES_DB:-reviewskits}
+    env_file:
+      - ../.env
     ports:
       - "5433:5432"
     volumes:

--- a/infra/docker-compose.no-proxy.yml
+++ b/infra/docker-compose.no-proxy.yml
@@ -1,8 +1,8 @@
 # ┌─────────────────────────────────────────────────────────────────┐
-# │  Proxy existant — Nginx, Caddy, HAProxy, Apache, etc.           │
-# │  Ports 80/443 déjà pris ? Utilisez ce fichier.                  │
-# │  Expose admin sur :8080 et API sur :3000 — pointez votre proxy  │
-# │  vers ces ports. SSL géré par votre proxy existant.             │
+# │  Existing Proxy — Nginx, Caddy, HAProxy, Apache, etc.           │
+# │  Ports 80/443 already taken? Use this file.                    │
+# │  Exposes admin on :8080 and API on :3000 — point your proxy    │
+# │  to these ports. SSL managed by your existing proxy.           │
 # │  Usage  : docker compose -f infra/docker-compose.no-proxy.yml up -d │
 # └─────────────────────────────────────────────────────────────────┘
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,6 +1,6 @@
 # ┌─────────────────────────────────────────────────────────────────┐
-# │  VPS standard — Traefik intégré, SSL automatique Let's Encrypt  │
-# │  Requis : un domaine pointé sur le serveur + ports 80/443 libres │
+# │  Standard VPS — Integrated Traefik, automatic Let's Encrypt SSL │
+# │  Requirement: A domain pointed to the server + free 80/443 ports │
 # │  Usage  : docker compose -f infra/docker-compose.yml up -d      │
 # └─────────────────────────────────────────────────────────────────┘
 
@@ -72,7 +72,7 @@ services:
     networks:
       - reviewskits
 
-  # ─── Base de données ──────────────────────────────────────────
+  # ─── DATABASE ──────────────────────────────────────────
   db:
     image: postgres:16-alpine
     restart: unless-stopped

--- a/knip.json
+++ b/knip.json
@@ -19,6 +19,10 @@
       "entry": ["docs/.vitepress/config.ts", "docs/**/*.md"],
       "project": ["docs/**/*.{md,ts}"]
     },
+    "packages/sdk-core": {
+      "entry": ["src/index.ts"],
+      "project": ["src/**/*.ts"]
+    },
     "packages/sdk-react": {
       "entry": ["src/index.ts"],
       "project": ["src/**/*.{ts,tsx}"]

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -21,6 +21,9 @@ export interface Testimonial {
     email?: string;
     title?: string;
   };
+  consent_public: boolean;
+  consent_internal: boolean;
+  consented_at: Date | null;
   created_at: Date;
 }
 
@@ -113,6 +116,9 @@ export interface RawReview {
   authorUrl?: string;
   createdAt: string;
   type: string;
+  consentPublic: boolean;
+  consentInternal: boolean;
+  consentedAt?: string | null;
   metadata?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## What does this PR do?

Implements an explicit, GDPR-compliant consent mechanism for testimonial submissions across the database, public forms, and admin dashboard.

Closes #<!-- issue number -->

---

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Chore (deps, config, tooling)

---

## Changes made

- **Database & Types:** Added `consentPublic`, `consentInternal`, and `consentedAt` to the `testimonials` table schema, and updated `@reviewskits/types` (with a minor changeset bump).
- **Backend API Validation:** Updated `submitReviewSchema` to require at least one consent strictly. Filtered public data repositories ([findApprovedByUser](cci:1://file:///home/franklin/Reviews%20Kits%20Project/reviews-kits/apps/server/src/domain/repositories/ITestimonialRepository.ts:13:2-13:125)) to logically omit any entry without `consentPublic = true`.
- **Public Form Collection:** Built and embedded a mandatory `ConsentStep` UI that restricts form submission until the checkboxes are actively checked by the user.
- **Admin Form Builder:** Exposed localization properties (`publicLabel`, `internalLabel`) to the step sidebar. Protected the step with a lock (`locked: true`) preventing accidental deletion by administrators.
- **Admin Dashboard Display:** Inserted a visual "Consent" column in the testimonials list view (using Globe 🌍 and Lock 🔒 icons) alongside an interactive "Public Only" checkbox filter. 
- **Tests Updated:** Injected `consentPublic: true` payloads into all relevant integration and security API tests ensuring 100% test passing rates.

---

## How to test

1. **Submit a Review:** Go to any public form configured by the builder, fill it out, and ensure the new opt-in checkboxes block submission until at least one is accepted. 
2. **Access the Admin Builder:** Enter the dashboard, start editing a form, verify you can change the text of the Data Consent step, and ensure there is no ability to delete it.
3. **Verify Dashboard Metrics:** Navigate to a form detail's testimonial list and verify the presence of the consent badges. Toggle the `Public Only` filter to confirm testimonials correctly respond to the new API queries.

---

## Checklist

- [x] My code follows the project conventions
- [x] I tested this locally
- [ ] I updated the documentation if needed
- [x] No console.log or debug code left
- [x] No `.env` or secrets committed
